### PR TITLE
🧹 Handle missing command expressively in Web Bridge

### DIFF
--- a/review_heatmap/errors.py
+++ b/review_heatmap/errors.py
@@ -38,3 +38,6 @@ class ReviewHeatmapError(Exception):
 
 class CollectionError(ReviewHeatmapError):
     pass
+
+class CommandError(ReviewHeatmapError):
+    pass

--- a/review_heatmap/web_bridge.py
+++ b/review_heatmap/web_bridge.py
@@ -43,9 +43,11 @@ from aqt.qt import QWidget
 from aqt.stats import DeckStats
 
 from .config import heatmap_colors, heatmap_modes
+from .errors import CommandError
 from .gui.contrib import invoke_contributions_dialog
 from .gui.extra import invoke_snanki
 from .gui.options import invoke_options_dialog
+from .libaddon.debug import logger
 
 if TYPE_CHECKING:
     from .libaddon.anki.configmanager import ConfigManager
@@ -144,9 +146,9 @@ class _CommandHandler:
     ) -> Any:
         handler = _command_handler_registry.get(command)
 
-        # TODO: handle no handler more expressively
         if not handler:
-            return None
+            logger.warning("No handler found for command: %s", command)
+            raise CommandError(f"No handler found for command: {command}")
 
         return handler(self, payload, context)  # type: ignore
 


### PR DESCRIPTION
🎯 What
Added robust error handling and logging for missing command handlers in the `ReviewHeatmapBridge`.
- Introduced a new `CommandError` exception in `review_heatmap/errors.py`.
- Updated `_CommandHandler.__call__` in `review_heatmap/web_bridge.py` to log a warning message and raise `CommandError` when a command is not found in the registry.

💡 Why
Currently, missing handlers silently return `None`, making it difficult to diagnose issues when a command from the frontend fails to find a matching backend handler. Providing a clearer mechanism (logging + exception) improves maintainability and debuggability.

✅ Verification
- Verified syntax with `python3 -m py_compile`.
- Verified code quality with `ruff`.
- Executed a verification script with mocked Anki/aqt modules to confirm that `_CommandHandler.__call__` correctly logs a warning and raises `CommandError` for unknown commands.
- Ran existing terminal command tests using `make check-commands` to ensure no regressions in existing command processing.

✨ Result
Missing web bridge commands are now explicitly logged as warnings and raise a specific exception, facilitating easier debugging of JS-to-Python communication issues.

---
*PR created automatically by Jules for task [13873347947898003346](https://jules.google.com/task/13873347947898003346) started by @ryusoh*