### PR TITLE
🔒 [security fix] Enable SSL verification for Forvo service requests

### DIFF
--- a/awesome_tts/awesometts/service/forvo.py
+++ b/awesome_tts/awesometts/service/forvo.py
@@ -822,8 +822,7 @@ class Forvo(Service):
 
             # run request
             headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0'}
-            # forvo's http server / WAF / frontend setup is weird, so we have to disable SSL verification
-            response = requests.get(url, headers=headers, verify=False)
+            response = requests.get(url, headers=headers)
             self._logger.debug(f'response.content: {response.content}')
 
             if response.status_code == 200:
@@ -843,7 +842,7 @@ class Forvo(Service):
                         audio_url = item['pathmp3']
                         break
 
-                response = requests.get(audio_url, verify=False)
+                response = requests.get(audio_url)
                 response.raise_for_status()
 
                 with open(path, 'wb') as audio:


### PR DESCRIPTION
🎯 **What:** Disabled SSL verification in HTTP requests to the Forvo service.
⚠️ **Risk:** By disabling SSL verification (`verify=False`), the application was vulnerable to Man-in-the-Middle (MITM) attacks. An attacker could intercept the traffic to steal API keys or modify the audio content being downloaded.
🛡️ **Solution:** Removed the 'verify=False' parameter from all 'requests.get()' calls in the Forvo service implementation, reverting to the default secure behavior of verifying SSL certificates. Removed the comment justifying the insecure practice.

Note: While the original code suggested Forvo had 'weird' SSL setup, modern checks indicate they use standard DigiCert/Cloudflare certificates. If users encounter errors, they should update their CA bundles (e.g., via 'certifi') rather than bypassing security.

---
*PR created automatically by Jules for task [14921893558407213584](https://jules.google.com/task/14921893558407213584) started by @ryusoh*