### PR TITLE
🧹 Remove unused `absolute_import` from `review_heatmap/libaddon/consts.py`

### DIFF
--- a/review_heatmap/libaddon/consts.py
+++ b/review_heatmap/libaddon/consts.py
@@ -33,7 +33,7 @@
 Package-wide constants
 """
 
-from __future__ import (absolute_import, division,
+from __future__ import (division,
                         print_function, unicode_literals)
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `absolute_import` from the `__future__` import statement in `review_heatmap/libaddon/consts.py` at line 36.

💡 **Why:** The `absolute_import` from `__future__` was imported but not utilized. Removing unused imports is a straightforward, low-risk change that directly improves code health by keeping files clean, enhancing readability, and satisfying linter checks.

✅ **Verification:** 
- Syntactic validity checked via `python3 -m py_compile review_heatmap/libaddon/consts.py`.
- Verified code passes the Ruff linter check without raising `F401` warnings for the unused import.
- Ran tests suite (`make check`) and all tests passed successfully.

✨ **Result:** Cleaned up code health in the `consts.py` file without affecting application behavior.

---
*PR created automatically by Jules for task [1364169160297422674](https://jules.google.com/task/1364169160297422674) started by @ryusoh*