### PR TITLE
🧹 Fix unused DBProxy import in review_heatmap/times.py

### DIFF
--- a/review_heatmap/times.py
+++ b/review_heatmap/times.py
@@ -33,6 +33,8 @@
 Shared datetime/timezone handling
 """
 
+from __future__ import annotations
+
 from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -40,7 +42,7 @@ if TYPE_CHECKING:
 
 
 def daystart_epoch(
-    db: "DBProxy",
+    db: DBProxy,
     time_specifier: Union[str, int],
     is_timestamp: bool = True,
     offset: int = 0,


### PR DESCRIPTION
🎯 **What:** Fixed an unused import warning for `DBProxy` in `review_heatmap/times.py`.
💡 **Why:** The import was only used inside a string literal (`"DBProxy"`) under a `TYPE_CHECKING` block. By adding `from __future__ import annotations` and removing the string quotes from the type hint, the linter correctly recognizes the type hint usage while avoiding runtime evaluation issues. This improves the codebase maintainability and reduces linter noise.
✅ **Verification:** Verified that `ruff check` passes cleanly without unused import warnings, and ran `python3 -m py_compile review_heatmap/times.py` to ensure no syntax errors were introduced. Run all other checks.
✨ **Result:** A cleaner file with properly evaluated type hints and no unused import warnings, without affecting runtime functionality.

---
*PR created automatically by Jules for task [9942691862410017450](https://jules.google.com/task/9942691862410017450) started by @ryusoh*