### PR TITLE
🧹 Remove unused DBProxy import in review_heatmap/activity.py

### DIFF
--- a/review_heatmap/activity.py
+++ b/review_heatmap/activity.py
@@ -52,7 +52,6 @@ from anki.errors import NotFoundError
 
 if TYPE_CHECKING:
     from anki.collection import Collection
-    from anki.dbproxy import DBProxy
 
 from .errors import CollectionError
 from .libaddon.anki.configmanager import ConfigManager
@@ -113,7 +112,6 @@ class ActivityReport(NamedTuple):
 class ActivityReporter:
     def __init__(self, col: "Collection", config: ConfigManager):
         self._col: "Collection"
-        self._db: "DBProxy"
 
         self._config: ConfigManager = config
         self.set_collection(col)


### PR DESCRIPTION
🎯 **What:** Removed the unused `from anki.dbproxy import DBProxy` import in `review_heatmap/activity.py` within the `TYPE_CHECKING` block. Also removed the uninitialized type hint `self._db: "DBProxy"` in `ActivityReporter.__init__`.
💡 **Why:** Removing dead code and unused imports improves readability and prevents linting errors. Since `self._db` is assigned dynamically later on, keeping an unassigned type hint tied to a removed import serves no purpose.
✅ **Verification:** Verified that `ruff check review_heatmap/activity.py` passes without errors and that the file complies correctly with `python3 -m py_compile review_heatmap/activity.py`.
✨ **Result:** A slightly cleaner and healthier codebase with no unused imports or references to `DBProxy`.

---
*PR created automatically by Jules for task [3678291370546659741](https://jules.google.com/task/3678291370546659741) started by @ryusoh*