### PR TITLE
🧹 Code Health: Remove unused `division` import from utils.py

### DIFF
--- a/review_heatmap/libaddon/utils.py
+++ b/review_heatmap/libaddon/utils.py
@@ -33,8 +33,8 @@
 Miscellaneuos utilities used around libaddon
 """
 
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, print_function,
+                        unicode_literals)
 
 import os
 


### PR DESCRIPTION
🎯 **What:** Removed unused `division` import from `__future__` in `review_heatmap/libaddon/utils.py`.
💡 **Why:** To improve code health, maintainability, and readability by reducing dead code and unnecessary dependencies.
✅ **Verification:** Verified that the syntax remains correct using `py_compile`, and verified that no existing tests or functionalities broke (using `make check` and `ruff`).
✨ **Result:** Cleaned up unused import, enhancing the codebase's neatness and adhering to clean code principles without breaking behavior.

---
*PR created automatically by Jules for task [15513422183261038882](https://jules.google.com/task/15513422183261038882) started by @ryusoh*