### PR TITLE
🧹 Fix unused import DeckBrowserContent in views.py

### DIFF
--- a/review_heatmap/views.py
+++ b/review_heatmap/views.py
@@ -33,6 +33,8 @@
 Integration with Anki views
 """
 
+from __future__ import annotations
+
 import json
 from abc import ABC
 from typing import TYPE_CHECKING, Callable, Optional
@@ -77,7 +79,7 @@ class DeckBrowserInjector(HeatmapInjector):
         deck_browser_will_render_content.append(self.on_deckbrowser_will_render_content)
 
     def on_deckbrowser_will_render_content(
-        self, deck_browser: DeckBrowser, content: "DeckBrowserContent"
+        self, deck_browser: DeckBrowser, content: DeckBrowserContent
     ):
         heatmap_html = self._controller.render_for_view(self._view)
         content.stats += heatmap_html
@@ -109,7 +111,7 @@ class OverviewInjector(HeatmapInjector):
         overview_did_refresh.append(self.overview_did_refresh)
 
     def overview_will_render_content(
-        self, overview: Overview, content: "OverviewContent"
+        self, overview: Overview, content: OverviewContent
     ):
         if overview.mw.col and overview.mw.col.sched._is_finished():
             return


### PR DESCRIPTION
🎯 **What:** Resolved an unused import warning for `DeckBrowserContent` in `review_heatmap/views.py`. Added `from __future__ import annotations` to use modern unquoted type hints.
💡 **Why:** Improves code readability, keeps type checkers happy, and resolves linter warnings without risking a runtime circular import, enhancing the codebase's overall health and maintainability.
✅ **Verification:** Verified syntax correctness using `python3 -m py_compile`, confirmed no linter errors using `ruff check`, ran unit tests using `make check`, and obtained a passing automated code review.
✨ **Result:** Cleaned up the typing in `views.py`, resolving the targeted code health issue perfectly.

---
*PR created automatically by Jules for task [3224087693215512496](https://jules.google.com/task/3224087693215512496) started by @ryusoh*