### PR TITLE
🧹 Fix unused import 'DeckId' warning in review_heatmap/types.py

### DIFF
--- a/review_heatmap/types.py
+++ b/review_heatmap/types.py
@@ -32,6 +32,8 @@
 from typing import TYPE_CHECKING
 
 
+__all__ = ["DeckId"]
+
 if TYPE_CHECKING:
     from anki.decks import DeckId
 else:


### PR DESCRIPTION
🎯 **What:** The `DeckId` import in `review_heatmap/types.py` was being flagged as an unused import. Added `__all__ = ["DeckId"]` to explicitly mark it as a public export.
💡 **Why:** This satisfies linters while cleanly communicating that the module exists to export these types. It completely maintains backward compatibility with the existing fallback to `int` for older versions of Anki.
✅ **Verification:** Ran `ruff check review_heatmap/types.py` to confirm the linter warning is resolved. Verified syntax with `python3 -m py_compile review_heatmap/types.py`. Code review approved the fix.
✨ **Result:** Improved code cleanliness and readability by resolving linter warnings safely without changing behavior.

---
*PR created automatically by Jules for task [4756027653539156397](https://jules.google.com/task/4756027653539156397) started by @ryusoh*