### PR TITLE
🧹 Fix Review Heatmap 'rid' search combining with other terms

### DIFF
--- a/review_heatmap/finder.py
+++ b/review_heatmap/finder.py
@@ -34,13 +34,9 @@ Finder extensions
 """
 
 import re
-from typing import List, Optional
+from typing import List
 
 from aqt import mw
-
-
-# FIXME: No longer works in combination with other search specifiers
-# e.g. deck:current, which we actually add in the overview view
 
 
 def _find_cards_reviewed_between(start_date: int, end_date: int) -> List[int]:
@@ -54,35 +50,22 @@ def _find_cards_reviewed_between(start_date: int, end_date: int) -> List[int]:
     )
 
 
-_re_rid = re.compile(r"^rid:([0-9]+):([0-9]+)$")
-
-
-def find_rid(search: str) -> Optional[List[int]]:
-    match = _re_rid.match(search)
-
-    if not match:
-        return None
-
-    start_date = int(match[1])
-    end_date = int(match[2])
-
-    return _find_cards_reviewed_between(start_date, end_date)
+_re_rid = re.compile(r"rid:([0-9]+):([0-9]+)")
 
 
 def on_browser_will_search(search_context):
-    search = search_context.search
-    if search.startswith("rid"):
-        found_ids = find_rid(search)
-    else:
-        return
+    def replace_match(match):
+        start_date = int(match.group(1))
+        end_date = int(match.group(2))
+        found_ids = _find_cards_reviewed_between(start_date, end_date)
 
-    if found_ids is None:
-        return
+        if not found_ids:
+            return "cid:0"
 
-    if hasattr(search_context, "card_ids"):
-        search_context.card_ids = found_ids  # type: ignore[attr-defined]
-    else:
-        search_context.ids = found_ids  # type: ignore[assignment]
+        return "cid:" + ",".join(str(i) for i in found_ids)
+
+    if "rid:" in search_context.search:
+        search_context.search = _re_rid.sub(replace_match, search_context.search)
 
 
 # HOOKS


### PR DESCRIPTION
🎯 **What:** The `rid:start:end` custom search specifier for Review Heatmap completely overwrote all Anki search results by explicitly setting `search_context.ids` (bypassing Anki's search backend). This made it impossible to combine it with other filters like `deck:current`. The legacy approach has been refactored.

💡 **Why:** By replacing the `rid:start:end` token in the query string (`search_context.search`) dynamically with a list of Anki card IDs (`cid:id1,id2`), we allow Anki's search engine to do the heavy lifting. This allows users to correctly combine `rid:` queries with native filters (e.g. tags or decks). This fixes the `FIXME` comment noting the technical debt and significantly improves the robustness of the search logic.

✅ **Verification:** I created a test script to evaluate the new regex replacement, verified the Python syntax via `py_compile`, and validated the code formatting and logic using `ruff`. The solution correctly avoids overriding `search_context.ids`, substituting empty sets with `cid:0` to guarantee consistent query execution. 

✨ **Result:** The codebase is cleaner, a technical debt `FIXME` was removed, and users can now accurately filter by deck, tag, or other query items simultaneously alongside the heatmap review dates.

---
*PR created automatically by Jules for task [3740137188229228907](https://jules.google.com/task/3740137188229228907) started by @ryusoh*