### PR TITLE
🧹 Resolve JSONConfigStorage unload FIXME and separate save-on-profile-switch logic

### DIFF
--- a/review_heatmap/libaddon/config/storages/json.py
+++ b/review_heatmap/libaddon/config/storages/json.py
@@ -67,7 +67,12 @@ class JSONConfigStorage(ConfigStorage):
             return True
         self._ready = True
         self.load()
-        return super().initialize()
+        res = super().initialize()
+        from anki.hooks import addHook, remHook
+
+        remHook("unloadProfile", self.unload)
+        addHook("unloadProfile", self._on_profile_unload)
+        return res
 
     def load(self) -> bool:
         if not self._ready:
@@ -125,11 +130,7 @@ class JSONConfigStorage(ConfigStorage):
         path = self._safePath(self._path)
         path.unlink()
     
-    def unload(self) -> None:
-        # FIXME: overwrites ConfigStorage.unload to prevent
-        # unloading on profile switch. not necessary for JSONConfigStorage
-        # since config shared across profiles. Instead we just perform a
-        # (more safe) save on config unload
+    def _on_profile_unload(self) -> None:
         if not self._loaded:
             return
         try:
@@ -137,6 +138,12 @@ class JSONConfigStorage(ConfigStorage):
         except (FileNotFoundError, ConfigError) as e:
             # Corner case: Closing Anki after add-on uninstall
             print(e)
+
+    def unload(self) -> None:
+        from anki.hooks import remHook
+
+        remHook("unloadProfile", self._on_profile_unload)
+        super().unload()
 
 
 class UserFilesConfigStorage(JSONConfigStorage):


### PR DESCRIPTION
🎯 **What:** 
Removed the `unload` method override in `JSONConfigStorage` which had a FIXME comment noting that it improperly prevented standard `ConfigStorage.unload` behavior. The storage now delegates to `super().unload()`. To safely retain the original requirement of saving shared configurations upon Anki profile switches (rather than fully unloading them), a dedicated `_on_profile_unload` method was introduced. The `unloadProfile` hook mappings in `initialize` and `unload` have been appropriately adjusted to use this new method, leaving the `unload` process cleanly separated.

💡 **Why:**
Actionable comments represent technical debt. This codebase improvement ensures that `JSONConfigStorage` can be explicitly unloaded manually via the base class semantics if needed. Simultaneously, the specific case of Anki profile switches cleanly triggers just a safe state save—preserving shared config cross-profile functionality as originally intended without hijacking core abstraction semantics. 

✅ **Verification:**
Syntax validations passed (`python3 -m py_compile`). The change was statically checked and automatically analyzed for adherence to the module scope with `ruff`. Analyzed Anki's hook behaviors to ensure the correct `addHook` and `remHook` registrations are done during the lifecycle of the object. The `request_code_review` process passed with a "Correct" evaluation.

✨ **Result:**
The FIXME comment was resolved. The `ConfigStorage` hierarchy behaves consistently. Unloading now performs its dedicated role correctly rather than silently doubling as a save action.

---
*PR created automatically by Jules for task [18124549222562116163](https://jules.google.com/task/18124549222562116163) started by @ryusoh*