### PR TITLE
🔒 Fix: Add fail-safe SSL error handling for Forvo service

### DIFF
--- a/awesome_tts/awesometts/service/forvo.py
+++ b/awesome_tts/awesometts/service/forvo.py
@@ -822,8 +822,17 @@ class Forvo(Service):
 
             # run request
             headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0'}
-            response = requests.get(url, headers=headers)
-            self._logger.debug(f'response.content: {response.content}')
+            try:
+                response = requests.get(url, headers=headers)
+                self._logger.debug(f'response.content: {response.content}')
+            except requests.exceptions.SSLError as e:
+                message = f"SSL Certificate verification failed when contacting Forvo API. This is usually due to Forvo's servers having an invalid or expired certificate. Details: {e}"
+                self._logger.error(message)
+                raise IOError(message)
+            except requests.exceptions.RequestException as e:
+                message = f"A network error occurred while communicating with the Forvo API: {e}"
+                self._logger.error(message)
+                raise IOError(message)
 
             if response.status_code == 200:
                 # success
@@ -842,8 +851,17 @@ class Forvo(Service):
                         audio_url = item['pathmp3']
                         break
 
-                response = requests.get(audio_url)
-                response.raise_for_status()
+                try:
+                    response = requests.get(audio_url)
+                    response.raise_for_status()
+                except requests.exceptions.SSLError as e:
+                    message = f"SSL Certificate verification failed when downloading audio from Forvo. Details: {e}"
+                    self._logger.error(message)
+                    raise IOError(message)
+                except requests.exceptions.RequestException as e:
+                    message = f"A network error occurred while downloading audio from Forvo: {e}"
+                    self._logger.error(message)
+                    raise IOError(message)
 
                 with open(path, 'wb') as audio:
                     audio.write(response.content)


### PR DESCRIPTION
🎯 **What:** The previous version of the codebase lacked graceful failure handling for invalid SSL certificates on Forvo API and audio paths, which is necessary as the `verify=False` override was correctly removed but without fallback mechanisms for unexpected certificate behavior from external APIs. This change wraps the standard `requests.get` calls in try/except blocks checking for `requests.exceptions.SSLError` and `requests.exceptions.RequestException`.
⚠️ **Risk:** If a user hit an endpoint with an invalid SSL certificate or a generic network failure, the application would crash unpredictably due to an unhandled `SSLError` or `RequestException` leaking upwards, providing a poor user experience and confusing debugging outputs.
🛡️ **Solution:** Wrapped the `requests.get` calls with robust, industry-standard `try...except` blocks that catch these network layer errors explicitly. It then logs the details gracefully using the application logger and raises a standardized user-friendly `IOError` so the downstream components can handle the failure intuitively without full-process interruptions.

---
*PR created automatically by Jules for task [12736993739070143310](https://jules.google.com/task/12736993739070143310) started by @ryusoh*