### PR TITLE
🧹 Fix unused import 'division' in consts.py

### DIFF
--- a/review_heatmap/libaddon/consts.py
+++ b/review_heatmap/libaddon/consts.py
@@ -33,8 +33,8 @@
 Package-wide constants
 """
 
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+from __future__ import (absolute_import, print_function,
+                        unicode_literals)
 
 
 def setAddonProperties(addon):


### PR DESCRIPTION
🎯 What: Removed the unused `division` import from `__future__` in `review_heatmap/libaddon/consts.py`.
💡 Why: Improves code cleanliness by removing unused imports, reducing clutter and maintaining a high standard of code health.
✅ Verification: Ran `ruff check` on the file and verified it passes cleanly. Also verified syntax with `py_compile`.
✨ Result: Cleaner code in `consts.py` with no change in functionality.

---
*PR created automatically by Jules for task [6865285822788736793](https://jules.google.com/task/6865285822788736793) started by @ryusoh*