### PR TITLE
🧹 Fix unused ConfigManager import and dead code in renderer.py

### DIFF
--- a/review_heatmap/renderer.py
+++ b/review_heatmap/renderer.py
@@ -33,6 +33,8 @@
 Heatmap and stats elements generation
 """
 
+from __future__ import annotations
+
 import json
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Tuple
@@ -127,9 +129,9 @@ class HeatmapRenderer:
         4.0,
     )
 
-    def __init__(self, mw: AnkiQt, reporter: ActivityReporter, config: "ConfigManager"):
+    def __init__(self, mw: AnkiQt, reporter: ActivityReporter, config: ConfigManager):
         self._mw: AnkiQt = mw
-        self._config: "ConfigManager" = config
+        self._config: ConfigManager = config
         self._reporter: ActivityReporter = reporter
         self._render_cache: Optional[_RenderCache] = None
 
@@ -156,7 +158,6 @@ class HeatmapRenderer:
             return HTML_MAIN_ELEMENT.format(content=HTML_INFO_NODATA, classes="")
 
         dynamic_legend = self._dynamic_legend(report.stats.activity_daily_avg.value)
-        stats_legend = self._stats_legend(dynamic_legend)
         heatmap_legend = self._heatmap_legend(dynamic_legend)
 
         classes = self._get_css_classes(view)


### PR DESCRIPTION
🎯 **What:** 
- Added `from __future__ import annotations` to `review_heatmap/renderer.py` to allow the `ConfigManager` import inside the `if TYPE_CHECKING:` block to be actively evaluated by the type checker without being wrapped in string quotes.
- Removed the unused `stats_legend` variable assignment in the `render` method which was flagged by Ruff as dead code.

💡 **Why:** 
The `ConfigManager` was previously imported for type hinting but referenced as a string literal `"ConfigManager"`, causing linters to flag the import as unused. Using `from __future__ import annotations` resolves the warning while maintaining type safety and preventing runtime circular dependencies. Removing `stats_legend` directly improves code health by eliminating dead code.

✅ **Verification:** 
- Ran `ruff check review_heatmap/renderer.py` which now passes successfully without any `F841` or unused import warnings.
- Ran `python3 -m py_compile review_heatmap/renderer.py` to ensure syntax validity.
- Executed `make check` to ensure no functionality regressions.

✨ **Result:** 
The code health issue is fully resolved. The module has cleaner, safer type hinting and zero linter warnings without breaking or changing any existing functionality.

---
*PR created automatically by Jules for task [5172439434126081011](https://jules.google.com/task/5172439434126081011) started by @ryusoh*