### PR TITLE
🧪 Fix calculate_future_due tests and bug with cid_to_deck=None

### DIFF
--- a/data/anki/generate_custom_stats.py
+++ b/data/anki/generate_custom_stats.py
@@ -74,6 +74,9 @@ def calculate_future_due(cards_data, cid_to_deck=None, max_days=None, anki_today
     if anki_today is None:
         anki_today = get_anki_today()
     
+    if cid_to_deck is None:
+        cid_to_deck = {}
+
     if max_days is None:
         # Find the maximum due date to determine range
         review_cards_due = [c.get("due", 0) for c in cards_data if c.get("queue") == 2]

--- a/data/anki/tests/test_calculate_future_due.py
+++ b/data/anki/tests/test_calculate_future_due.py
@@ -11,53 +11,70 @@ def test_calculate_future_due_basic():
     """Test with a mix of mature and young cards."""
     anki_today = 100
     cards_data = [
-        {"due": 100, "ivl": 21, "queue": 2}, # Today, mature
-        {"due": 100, "ivl": 10, "queue": 2}, # Today, young
-        {"due": 101, "ivl": 25, "queue": 2}, # Tomorrow, mature
-        {"due": 102, "ivl": 5,  "queue": 2}, # Day after, young
+        {"id": 1, "due": 100, "ivl": 21, "queue": 2}, # Today, mature
+        {"id": 2, "due": 100, "ivl": 10, "queue": 2}, # Today, young
+        {"id": 3, "due": 101, "ivl": 25, "queue": 2}, # Tomorrow, mature
+        {"id": 4, "due": 102, "ivl": 5,  "queue": 2}, # Day after, young
     ]
+    cid_to_deck = {1: "DeckA", 2: "DeckB", 3: "DeckA", 4: "DeckB"}
 
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck=cid_to_deck, max_days=3, anki_today=anki_today)
 
     assert len(result) == 3
     assert result[0] == {"day": 0, "mature": 1, "young": 1}
     assert result[1] == {"day": 1, "mature": 1, "young": 0}
     assert result[2] == {"day": 2, "mature": 0, "young": 1}
 
+    assert "DeckA" in result_by_deck
+    assert result_by_deck["DeckA"] == [
+        {"day": 0, "mature": 1, "young": 0},
+        {"day": 1, "mature": 1, "young": 0}
+    ]
+
+    assert "DeckB" in result_by_deck
+    assert result_by_deck["DeckB"] == [
+        {"day": 0, "mature": 0, "young": 1},
+        {"day": 2, "mature": 0, "young": 1}
+    ]
+
 def test_calculate_future_due_empty():
     """Test with empty cards_data."""
-    result = calculate_future_due([], cid_to_deck={}, max_days=None, anki_today=100)
+    result, result_by_deck = calculate_future_due([], cid_to_deck={}, max_days=None, anki_today=100)
     assert result == []
+    assert result_by_deck == {}
 
 def test_calculate_future_due_no_reviews():
     """Test with cards but no review cards (queue=2)."""
     cards_data = [
-        {"due": 100, "ivl": 21, "queue": 0}, # New card
-        {"due": 100, "ivl": 1,  "queue": 1}, # Learning card
+        {"id": 1, "due": 100, "ivl": 21, "queue": 0}, # New card
+        {"id": 2, "due": 100, "ivl": 1,  "queue": 1}, # Learning card
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=100)
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=100)
     assert result == []
+    assert result_by_deck == {}
 
 def test_calculate_future_due_overdue():
     """Overdue cards should be skipped."""
     anki_today = 100
     cards_data = [
-        {"due": 99, "ivl": 21, "queue": 2}, # Overdue
-        {"due": 100, "ivl": 21, "queue": 2}, # Today
+        {"id": 1, "due": 99, "ivl": 21, "queue": 2}, # Overdue
+        {"id": 2, "due": 100, "ivl": 21, "queue": 2}, # Today
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
     # max_due is 100. max_days = 100 - 100 + 1 = 1.
     assert len(result) == 1
     assert result[0] == {"day": 0, "mature": 1, "young": 0}
+    assert "Unknown" in result_by_deck
+    assert len(result_by_deck["Unknown"]) == 1
 
 def test_calculate_future_due_max_days_limit():
     """Cards scheduled beyond max_days should be skipped."""
     anki_today = 100
     cards_data = [
-        {"due": 100, "ivl": 21, "queue": 2},
-        {"due": 105, "ivl": 21, "queue": 2},
+        {"id": 1, "due": 100, "ivl": 21, "queue": 2},
+        {"id": 2, "due": 105, "ivl": 21, "queue": 2},
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
     assert len(result) == 3
     assert result[0] == {"day": 0, "mature": 1, "young": 0}
     assert result[1] == {"day": 1, "mature": 0, "young": 0}
@@ -67,20 +84,20 @@ def test_calculate_future_due_maturity_boundary():
     """Test the 21-day maturity boundary."""
     anki_today = 100
     cards_data = [
-        {"due": 100, "ivl": 20, "queue": 2}, # Young
-        {"due": 100, "ivl": 21, "queue": 2}, # Mature
+        {"id": 1, "due": 100, "ivl": 20, "queue": 2}, # Young
+        {"id": 2, "due": 100, "ivl": 21, "queue": 2}, # Mature
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=anki_today)
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=anki_today)
     assert result[0] == {"day": 0, "mature": 1, "young": 1}
 
 def test_calculate_future_due_auto_max_days():
     """Test automatic max_days calculation."""
     anki_today = 100
     cards_data = [
-        {"due": 102, "ivl": 21, "queue": 2},
+        {"id": 1, "due": 102, "ivl": 21, "queue": 2},
     ]
     # max_due = 102. anki_today = 100. max_days = 102 - 100 + 1 = 3.
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
     assert len(result) == 3
     assert result[0]["day"] == 0
     assert result[1]["day"] == 1
@@ -90,7 +107,43 @@ def test_calculate_future_due_auto_max_days():
 def test_calculate_future_due_fallback_today(monkeypatch):
     """Test that it falls back to get_anki_today() if anki_today is None."""
     monkeypatch.setattr("generate_custom_stats.get_anki_today", lambda: 500)
-    cards_data = [{"due": 500, "ivl": 10, "queue": 2}]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=None)
+    cards_data = [{"id": 1, "due": 500, "ivl": 10, "queue": 2}]
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=None)
     assert len(result) == 1
     assert result[0] == {"day": 0, "mature": 0, "young": 1}
+
+def test_calculate_future_due_missing_cid_to_deck():
+    """Test that the function works without error when cid_to_deck is None."""
+    cards_data = [{"id": 1, "due": 100, "ivl": 21, "queue": 2}]
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck=None, max_days=1, anki_today=100)
+    assert len(result) == 1
+    assert "Unknown" in result_by_deck
+    assert result_by_deck["Unknown"] == [{"day": 0, "mature": 1, "young": 0}]
+
+def test_calculate_future_due_missing_keys():
+    """Test that missing keys in a card dictionary are handled gracefully."""
+    cards_data = [
+        # Missing 'due' -> defaults to 0, which means overdue (100 - 0 = -100 days from now), so it's skipped
+        {"id": 1, "ivl": 21, "queue": 2},
+        # Missing 'ivl' -> defaults to 0 -> young
+        {"id": 2, "due": 100, "queue": 2},
+        # Missing 'queue' -> defaults to 0 -> non-review -> skipped
+        {"id": 3, "due": 100, "ivl": 21},
+        # Missing 'id' -> handled fine, defaults to Unknown deck
+        {"due": 100, "ivl": 21, "queue": 2},
+    ]
+    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={1: "A", 2: "B", 3: "C"}, max_days=1, anki_today=100)
+
+    # We expect the 2nd card to be processed as young, and the 4th card as mature.
+    assert len(result) == 1
+    assert result[0] == {"day": 0, "mature": 1, "young": 1}
+
+    assert "B" in result_by_deck
+    assert result_by_deck["B"] == [{"day": 0, "mature": 0, "young": 1}]
+
+    assert "Unknown" in result_by_deck
+    assert result_by_deck["Unknown"] == [{"day": 0, "mature": 1, "young": 0}]
+
+    # "A" and "C" should not be present because those cards were skipped
+    assert "A" not in result_by_deck
+    assert "C" not in result_by_deck


### PR DESCRIPTION
🎯 **What:** The existing tests for `calculate_future_due` in `data/anki/generate_custom_stats.py` were broken because the function recently began returning a tuple `(result_global, result_by_deck)` instead of a list. In addition, there was a bug in `calculate_future_due` where calling it with its default parameter `cid_to_deck=None` caused an `AttributeError` when accessing `cid_to_deck.get()`.

📊 **Coverage:**
- Updated all existing tests to correctly unpack the tuple return type.
- Added test coverage for `cid_to_deck=None` to prevent the `AttributeError`.
- Added test coverage for missing keys (`due`, `ivl`, `queue`, `id`) to ensure they handle defaults gracefully.

✨ **Result:** Test suite is passing and edge cases are explicitly tested. No more `AttributeError` when `cid_to_deck` is `None`.

---
*PR created automatically by Jules for task [10734872067732715398](https://jules.google.com/task/10734872067732715398) started by @ryusoh*