### PR TITLE
🧹 Code Health: Remove unused `absolute_import` in `review_heatmap` utils

### DIFF
--- a/review_heatmap/libaddon/utils.py
+++ b/review_heatmap/libaddon/utils.py
@@ -33,8 +33,7 @@
 Miscellaneuos utilities used around libaddon
 """
 
-from __future__ import (absolute_import, division,
-                        print_function, unicode_literals)
+from __future__ import (division, print_function, unicode_literals)
 
 import os
 


### PR DESCRIPTION
🎯 **What:** Removed unused `absolute_import` from the `__future__` import statement in `review_heatmap/libaddon/utils.py`.
💡 **Why:** `absolute_import` is the default behavior in Python 3. Removing the unused and redundant import cleans up the file and fixes a code health/linter issue, improving overall maintainability without changing any functionality.
✅ **Verification:** Verified that `review_heatmap/libaddon/utils.py` passes `py_compile` syntax checks. The linter also no longer complains about the unused `absolute_import`.
✨ **Result:** A cleaner `utils.py` with no unused `__future__` imports, adhering to better Python 3 code health standards.

---
*PR created automatically by Jules for task [4627856014811245263](https://jules.google.com/task/4627856014811245263) started by @ryusoh*