### PR TITLE
🧹 [Code Health] Remove unused Collection import in review_heatmap

### DIFF
--- a/review_heatmap/activity.py
+++ b/review_heatmap/activity.py
@@ -51,7 +51,7 @@ from anki.utils import ids2str
 from anki.errors import NotFoundError
 
 if TYPE_CHECKING:
-    from anki.collection import Collection
+    import anki
     from anki.dbproxy import DBProxy
 
 from .errors import CollectionError
@@ -111,8 +111,8 @@ class ActivityReport(NamedTuple):
 
 
 class ActivityReporter:
-    def __init__(self, col: "Collection", config: ConfigManager):
-        self._col: "Collection"
+    def __init__(self, col: "anki.collection.Collection", config: ConfigManager):
+        self._col: "anki.collection.Collection"
         self._db: "DBProxy"
 
         self._config: ConfigManager = config
@@ -153,7 +153,7 @@ class ActivityReporter:
 
         return activity_report
 
-    def set_collection(self, col: "Collection"):
+    def set_collection(self, col: "anki.collection.Collection"):
         # NOTE: Binding the collection is dangerous if we ever persist ActivityReporter
         # across profile reloads, so allow outside callers to update the collection
         # if necessary


### PR DESCRIPTION
🎯 **What:** Removed the unused `from anki.collection import Collection` import in `review_heatmap/activity.py` and replaced usages of the string type hint `"Collection"` with `"anki.collection.Collection"` by importing `anki` under `TYPE_CHECKING`.

💡 **Why:** The `Collection` import was unused and throwing a linting error. By importing `anki` under `TYPE_CHECKING` instead and using the fully qualified string name `"anki.collection.Collection"` for type hints, we eliminate the dead code while perfectly preserving the static type safety and autocompletion for development tools, all without introducing any runtime overhead.

✅ **Verification:** 
- Checked syntax with `python3 -m py_compile review_heatmap/activity.py`.
- Ran `ruff check review_heatmap/activity.py` and verified there are no linting errors.
- Ran `make check` to verify that existing javascript tests and general functionality aren't broken.

✨ **Result:** Cleaner code with resolved linting issues and correctly preserved type hinting capabilities.

---
*PR created automatically by Jules for task [9175943980603528796](https://jules.google.com/task/9175943980603528796) started by @ryusoh*