### PR TITLE
🧹 [Code Health] Remove empty _onClose method in extra.py

### DIFF
--- a/review_heatmap/gui/extra.py
+++ b/review_heatmap/gui/extra.py
@@ -265,7 +265,7 @@ class Snanki(QDialog):
         if self.foodPlaced is False:
             self.foodX = randrange(24) * 12
             self.foodY = randrange(2, 24) * 12
-            if not [self.foodX, self.foodY] in self.snakeArray:
+            if [self.foodX, self.foodY] not in self.snakeArray:
                 self.foodPlaced = True
         painter.setBrush(QColor("#ffdd55"))
         painter.drawRect(self.foodX, self.foodY, 12, 12)
@@ -285,16 +285,6 @@ class Snanki(QDialog):
         else:
             QFrame.timerEvent(self, event)
 
-    def _onClose(self):
-        pass
-
-    def accept(self):
-        self._onClose()
-        super().accept()
-
-    def reject(self):
-        self._onClose()
-        super().reject()
 
 
 defaults: Dict[str, Dict] = {


### PR DESCRIPTION
🎯 **What:** Removed the empty `_onClose` method and the redundant `accept` and `reject` overrides from the `Snanki` class in `review_heatmap/gui/extra.py`.
💡 **Why:** Removing empty and redundant functions removes dead code, which simplifies the class structure, makes the codebase cleaner, and improves overall maintainability and readability without altering behavior.
✅ **Verification:** Ran Python compiler checks (`python3 -m py_compile`) and `ruff check`, confirming no syntax errors or new linting issues exist (a preexisting E713 issue was also auto-fixed). In addition, running `make check` demonstrated that 123 tests passed correctly without introducing any regressions.
✨ **Result:** The codebase is cleaner and relies on standard `QDialog` behavior cleanly, reducing unnecessary boilerplate.

---
*PR created automatically by Jules for task [7559151001270241102](https://jules.google.com/task/7559151001270241102) started by @ryusoh*