### PR TITLE
🧪 Update tests for calculate_future_due

### DIFF
--- a/data/anki/tests/test_calculate_future_due.py
+++ b/data/anki/tests/test_calculate_future_due.py
@@ -17,17 +17,18 @@ def test_calculate_future_due_basic():
         {"due": 102, "ivl": 5,  "queue": 2}, # Day after, young
     ]
 
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
 
-    assert len(result) == 3
-    assert result[0] == {"day": 0, "mature": 1, "young": 1}
-    assert result[1] == {"day": 1, "mature": 1, "young": 0}
-    assert result[2] == {"day": 2, "mature": 0, "young": 1}
+    assert len(result_global) == 3
+    assert result_global[0] == {"day": 0, "mature": 1, "young": 1}
+    assert result_global[1] == {"day": 1, "mature": 1, "young": 0}
+    assert result_global[2] == {"day": 2, "mature": 0, "young": 1}
 
 def test_calculate_future_due_empty():
     """Test with empty cards_data."""
-    result = calculate_future_due([], cid_to_deck={}, max_days=None, anki_today=100)
-    assert result == []
+    result_global, result_by_deck = calculate_future_due([], cid_to_deck={}, max_days=None, anki_today=100)
+    assert result_global == []
+    assert result_by_deck == {}
 
 def test_calculate_future_due_no_reviews():
     """Test with cards but no review cards (queue=2)."""
@@ -35,8 +36,9 @@ def test_calculate_future_due_no_reviews():
         {"due": 100, "ivl": 21, "queue": 0}, # New card
         {"due": 100, "ivl": 1,  "queue": 1}, # Learning card
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=100)
-    assert result == []
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=100)
+    assert result_global == []
+    assert result_by_deck == {}
 
 def test_calculate_future_due_overdue():
     """Overdue cards should be skipped."""
@@ -45,10 +47,10 @@ def test_calculate_future_due_overdue():
         {"due": 99, "ivl": 21, "queue": 2}, # Overdue
         {"due": 100, "ivl": 21, "queue": 2}, # Today
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
     # max_due is 100. max_days = 100 - 100 + 1 = 1.
-    assert len(result) == 1
-    assert result[0] == {"day": 0, "mature": 1, "young": 0}
+    assert len(result_global) == 1
+    assert result_global[0] == {"day": 0, "mature": 1, "young": 0}
 
 def test_calculate_future_due_max_days_limit():
     """Cards scheduled beyond max_days should be skipped."""
@@ -57,11 +59,11 @@ def test_calculate_future_due_max_days_limit():
         {"due": 100, "ivl": 21, "queue": 2},
         {"due": 105, "ivl": 21, "queue": 2},
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
-    assert len(result) == 3
-    assert result[0] == {"day": 0, "mature": 1, "young": 0}
-    assert result[1] == {"day": 1, "mature": 0, "young": 0}
-    assert result[2] == {"day": 2, "mature": 0, "young": 0}
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=3, anki_today=anki_today)
+    assert len(result_global) == 3
+    assert result_global[0] == {"day": 0, "mature": 1, "young": 0}
+    assert result_global[1] == {"day": 1, "mature": 0, "young": 0}
+    assert result_global[2] == {"day": 2, "mature": 0, "young": 0}
 
 def test_calculate_future_due_maturity_boundary():
     """Test the 21-day maturity boundary."""
@@ -70,8 +72,8 @@ def test_calculate_future_due_maturity_boundary():
         {"due": 100, "ivl": 20, "queue": 2}, # Young
         {"due": 100, "ivl": 21, "queue": 2}, # Mature
     ]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=anki_today)
-    assert result[0] == {"day": 0, "mature": 1, "young": 1}
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=anki_today)
+    assert result_global[0] == {"day": 0, "mature": 1, "young": 1}
 
 def test_calculate_future_due_auto_max_days():
     """Test automatic max_days calculation."""
@@ -80,17 +82,72 @@ def test_calculate_future_due_auto_max_days():
         {"due": 102, "ivl": 21, "queue": 2},
     ]
     # max_due = 102. anki_today = 100. max_days = 102 - 100 + 1 = 3.
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
-    assert len(result) == 3
-    assert result[0]["day"] == 0
-    assert result[1]["day"] == 1
-    assert result[2]["day"] == 2
-    assert result[2]["mature"] == 1
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=None, anki_today=anki_today)
+    assert len(result_global) == 3
+    assert result_global[0]["day"] == 0
+    assert result_global[1]["day"] == 1
+    assert result_global[2]["day"] == 2
+    assert result_global[2]["mature"] == 1
 
 def test_calculate_future_due_fallback_today(monkeypatch):
     """Test that it falls back to get_anki_today() if anki_today is None."""
     monkeypatch.setattr("generate_custom_stats.get_anki_today", lambda: 500)
     cards_data = [{"due": 500, "ivl": 10, "queue": 2}]
-    result = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=None)
-    assert len(result) == 1
-    assert result[0] == {"day": 0, "mature": 0, "young": 1}
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=None)
+    assert len(result_global) == 1
+    assert result_global[0] == {"day": 0, "mature": 0, "young": 1}
+
+def test_calculate_future_due_by_deck():
+    """Test that result_by_deck correctly splits data by deck."""
+    anki_today = 100
+    cards_data = [
+        {"id": 1, "due": 100, "ivl": 21, "queue": 2}, # Deck A, mature
+        {"id": 2, "due": 101, "ivl": 10, "queue": 2}, # Deck A, young
+        {"id": 3, "due": 100, "ivl": 25, "queue": 2}, # Deck B, mature
+        {"id": 4, "due": 102, "ivl": 5,  "queue": 2}, # Unknown, young
+    ]
+    cid_to_deck = {
+        1: "Deck A",
+        2: "Deck A",
+        3: "Deck B"
+    }
+
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck=cid_to_deck, max_days=3, anki_today=anki_today)
+
+    # Check global stats
+    assert len(result_global) == 3
+    assert result_global[0] == {"day": 0, "mature": 2, "young": 0}
+    assert result_global[1] == {"day": 1, "mature": 0, "young": 1}
+    assert result_global[2] == {"day": 2, "mature": 0, "young": 1}
+
+    # Check by deck stats
+    assert "Deck A" in result_by_deck
+    assert "Deck B" in result_by_deck
+    assert "Unknown" in result_by_deck
+
+    # Deck A has due 100 and 101
+    assert result_by_deck["Deck A"] == [
+        {"day": 0, "mature": 1, "young": 0},
+        {"day": 1, "mature": 0, "young": 1}
+    ]
+
+    # Deck B has due 100
+    assert result_by_deck["Deck B"] == [
+        {"day": 0, "mature": 1, "young": 0}
+    ]
+
+    # Unknown has due 102
+    assert result_by_deck["Unknown"] == [
+        {"day": 2, "mature": 0, "young": 1}
+    ]
+
+def test_calculate_future_due_cid_to_deck_none():
+    """Test when cid_to_deck is completely empty or not provided properly."""
+    anki_today = 100
+    cards_data = [
+        {"id": 1, "due": 100, "ivl": 21, "queue": 2},
+    ]
+
+    result_global, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=anki_today)
+    assert "Unknown" in result_by_deck
+    assert result_by_deck["Unknown"] == [{"day": 0, "mature": 1, "young": 0}]


### PR DESCRIPTION
🎯 **What:** The existing tests for `calculate_future_due` in `data/anki/generate_custom_stats.py` were failing because the function was updated to return a tuple `(result_global, result_by_deck)` instead of a single list `result_global`. This PR updates the tests to correctly unpack the return value, and introduces tests for the `result_by_deck` output.
  
📊 **Coverage:** The tests have been modified to successfully test the original `result_global` return list and correctly assert expected edge behavior, resolving the failing pipeline. Additional tests (`test_calculate_future_due_by_deck` and `test_calculate_future_due_cid_to_deck_none`) have been added to verify that cards are correctly mapped and split according to `cid_to_deck`.
  
✨ **Result:** 10/10 tests pass smoothly under pytest, resolving the breaking CI and restoring complete test coverage over the core Anki stats module logic.

---
*PR created automatically by Jules for task [2572102901405553682](https://jules.google.com/task/2572102901405553682) started by @ryusoh*