### PR TITLE
🧹 Fix: Handle missing command in Web Bridge

### DIFF
--- a/review_heatmap/web_bridge.py
+++ b/review_heatmap/web_bridge.py
@@ -105,11 +105,14 @@ class HeatmapBridge:
         payload: Optional[str]
 
         try:
-            # TODO: handle no command
             command, payload = command_and_payload.split(self._payload_splitter, 1)
         except ValueError:
             command = command_and_payload
             payload = None
+
+        if not command:
+            logger.warning("Empty command received in Web Bridge message: '%s'", message)
+            return None
 
         # TODO: decode payload JSON
 


### PR DESCRIPTION
🎯 What
Add explicit handling for missing commands in the Web Bridge (`review_heatmap/web_bridge.py:106`), rather than passing an empty command string further down.

💡 Why
The previous code split the identifier and the payload, but if no command was present, it ended up propagating an empty string as a command to `_command_handler`. This resulted in a cryptic exception. By explicitly handling empty commands, we improve stability, provide more informative warnings, and remove an outstanding TODO.

✅ Verification
A standalone Python script was used to mock `HeatmapBridge` parsing logic and confirmed that:
1. Valid commands invoke `_command_handler` as expected.
2. Valid commands without payloads default the payload to `None`.
3. An empty command string is safely ignored (logging a warning and returning `None`), and `_command_handler` is bypassed.

✨ Result
Empty Web Bridge messages are now safely ignored with a logged warning, preventing unexpected `CommandError` exceptions and adhering to cleaner code.

---
*PR created automatically by Jules for task [17792996596552010037](https://jules.google.com/task/17792996596552010037) started by @ryusoh*