### PR TITLE
🎨 Palette: Improve terminal error accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2023-10-24 - Dynamic ARIA Live Regions vs Global Elements
+
+**Learning:** Reusing a single global static HTML element (like `<div id="error">`) for ARIA live region announcements (e.g., `role="alert" aria-live="assertive"`) can be risky. Changing its visual display properties or DOM position to handle dynamic errors (like terminal outputs) can break the visual experience for sighted users or conflict with existing error-handling logic.
+**Action:** When dynamically appending text that needs immediate screen reader announcement (like terminal error lines), it is safer and more robust to inject the `role="alert"` and `aria-live="assertive"` attributes directly onto the newly created specific DOM elements (e.g., the `div.line` representing the error) rather than modifying global error containers.

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -36,6 +36,12 @@ function appendLine(text, variant = "info") {
 
   const line = document.createElement("div");
   line.className = `terminal-line variant-${variant}`;
+
+  if (variant === "error") {
+    line.setAttribute("role", "alert");
+    line.setAttribute("aria-live", "assertive");
+  }
+
   line.textContent = text;
   terminalOutput.appendChild(line);
   terminalOutput.scrollTop = terminalOutput.scrollHeight;


### PR DESCRIPTION
💡 What: The UX enhancement added dynamically applied `role="alert"` and `aria-live="assertive"` to new terminal error lines when they are appended to the DOM.
🎯 Why: The user problem it solves is that visually impaired users utilizing screen readers would not be notified of errors emitted by the terminal application because the generated divs were not marked as live regions, leaving them confused about the state of their commands.
📸 Before/After: Visual presentation is identical (no styling changes), ensuring mouse and visual users see the exact same layout.
♿ Accessibility: Screen reader users will now immediately hear terminal error messages correctly announced when terminal commands fail, drastically improving the application's usability.

(Documented learnings in .jules/palette.md about using targeted dynamic elements instead of mutating global `#error` divs).

---
*PR created automatically by Jules for task [6300992710667819879](https://jules.google.com/task/6300992710667819879) started by @ryusoh*