### PR TITLE
Palette: Add focus-visible styles for interactive chart legends

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2024-06-12 - Missing Focus Indicators on Interactive Elements
+
+**Learning:** When elements like chart legend items are given `tabindex="0"` and `role="button"` to become keyboard accessible, they still lack visual focus indicators by default. Keyboard users have no visual context of their current position when tabbing through these elements.
+**Action:** Always provide explicit `:focus-visible` styles for any dynamically created or custom interactive elements that have been made keyboard accessible, ensuring users can clearly see which element currently has focus.

--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -156,6 +156,12 @@
   transition: opacity 0.2s ease;
 }
 
+.chart-legend span[data-dataset-index]:focus-visible {
+  outline: 2px solid rgba(73, 168, 236, 0.85);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .chart-legend span.legend-disabled {
   opacity: 0.35;
   text-decoration: line-through;


### PR DESCRIPTION
💡 **What**: Added `:focus-visible` styles to the interactive chart legend items.
🎯 **Why**: When users navigate through the legend items via keyboard (Tab), they lacked visual indication of which item had focus, despite the elements having `role="button"` and `tabindex="0"`.
📸 **Before/After**: The focused item now receives a clear, distinct outline.
♿ **Accessibility**: Considerably improves keyboard navigation by giving users spatial and visual context for their actions.

---
*PR created automatically by Jules for task [8196060625086474474](https://jules.google.com/task/8196060625086474474) started by @ryusoh*