### PR TITLE
🎨 Palette: Add focus-visible outline to chart legend items

### DIFF
--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -154,6 +154,13 @@
   cursor: pointer;
   user-select: none;
   transition: opacity 0.2s ease;
+  outline: none;
+}
+
+.chart-legend span[data-dataset-index]:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 4px;
+  border-radius: 2px;
 }
 
 .chart-legend span.legend-disabled {


### PR DESCRIPTION
💡 **What:** Added a `:focus-visible` outline styling to the interactive chart legend items in the terminal interface.
🎯 **Why:** The interactive chart legend items act as buttons allowing users to toggle dataset visibility. They already had `role="button"` and `tabindex="0"`, but they completely lacked any visual focus indication when navigated to using a keyboard, making the interface confusing and inaccessible for keyboard-only users.
📸 **Before/After:** Before, pressing Tab to focus the legend items did nothing visually. Now, a clear, primary-colored outline appears around the active item when focused via keyboard.
♿ **Accessibility:** This directly improves keyboard accessibility and conforms to WCAG guidelines by ensuring interactive elements have a visible focus state, while preventing the focus outline from showing unnecessarily during mouse clicks (by using `:focus-visible` instead of `:focus`).

---
*PR created automatically by Jules for task [5062300614356183210](https://jules.google.com/task/5062300614356183210) started by @ryusoh*