### PR TITLE
Palette: Add focus indicators to sortable table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2025-03-27 - Focus Visible Styles for Table Headers
+
+**Learning:** Table headers (`th` elements) configured as buttons (`role="button"`, `tabindex="0"`) can receive keyboard focus, but default browser focus outlines are often removed or masked by custom CSS (e.g., Apple-style gradients, background colors), leaving keyboard-only users with no visual indication of their current location.
+**Action:** When converting semantic but non-interactive elements like `th` into interactive components, explicitly define a `:focus-visible` pseudo-class to ensure keyboard users have a clear visual focus indicator that aligns with the design system, such as `outline: 2px solid var(--primary-color)`.

--- a/css/table.css
+++ b/css/table.css
@@ -281,3 +281,9 @@ thead tr th:hover {
     z-index: 1;
   }
 }
+
+th[role="button"]:focus-visible {
+  outline: 2px solid var(--primary-color, #f0b90b);
+  outline-offset: -2px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
💡 What: Added a :focus-visible outline to interactive table headers (`th[role="button"]`).\n🎯 Why: Keyboard users had no visual indication of which table column header was currently focused, making it difficult to know which column to sort by via keyboard.\n📸 Before/After: Before, tabbing through headers showed no visual change. After, a clear 2px primary color outline appears around the focused header.\n♿ Accessibility: Improves WCAG 2.1 Success Criterion 2.4.7 Focus Visible compliance for keyboard navigation.

---
*PR created automatically by Jules for task [3640558282240214954](https://jules.google.com/task/3640558282240214954) started by @ryusoh*