### PR TITLE
Palette: Add focus-visible styles to chart legend items

### DIFF
--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -184,3 +184,9 @@
 .legend-color.color-relearn {
   background: rgba(234, 67, 53, 0.85);
 }
+
+.chart-legend span[data-dataset-index]:focus-visible {
+  outline: 2px solid var(--primary-color, #f0b90b);
+  outline-offset: 4px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
**What:** 
Adds a visual focus outline (`:focus-visible`) to the interactive chart legend items.

**Why:** 
The interactive legend toggles (made clickable via `role="button"` and `tabindex="0"` in JavaScript) did not have any focus styling. Without an outline, keyboard-only users navigating the interface using the `Tab` key cannot see which toggle is currently focused.

**Accessibility:** 
This change specifically uses the `:focus-visible` pseudo-class to ensure the outline only appears during keyboard navigation, preserving a clean UI for mouse users while providing critical visual context for keyboard users.

---
*PR created automatically by Jules for task [9723145406687030691](https://jules.google.com/task/9723145406687030691) started by @ryusoh*