### PR TITLE
Palette: Add focus visible styles to interactive components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2024-03-29 - Keyboard Accessibility for Custom Interactive Elements
+
+**Learning:** Adding tabindex="0" and role="button" to custom interactive elements (like th.sortable, filter dropdowns, and chart legends) is insufficient for full keyboard accessibility if visual focus indicators are missing. Users navigating via keyboard cannot perceive which element has focus, rendering the interface unusable.
+**Action:** Always pair tabindex="0" with explicit :focus-visible CSS rules using existing design system variables (e.g., outlines or background highlights). This ensures keyboard users have clear visual context without compromising the experience for mouse users.

--- a/css/terminal/chart.css
+++ b/css/terminal/chart.css
@@ -156,6 +156,12 @@
   transition: opacity 0.2s ease;
 }
 
+.chart-legend span[data-dataset-index]:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .chart-legend span.legend-disabled {
   opacity: 0.35;
   text-decoration: line-through;

--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -127,6 +127,13 @@ th.filterable {
   user-select: none;
 }
 
+th.sortable:focus-visible,
+th.filterable:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+  border-radius: 4px;
+}
+
 .sort-indicator,
 .filter-indicator {
   display: inline-flex;
@@ -186,4 +193,10 @@ th.sortable[data-sort="desc"] .sort-indicator::after {
 
 .filter-dropdown div:hover {
   background-color: var(--hover-bg);
+}
+
+.filter-dropdown div:focus-visible {
+  background-color: var(--hover-bg);
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
 }


### PR DESCRIPTION
💡 What: Added `:focus-visible` styles to interactive table headers, filter dropdowns, and chart legends.
🎯 Why: Elements with `tabindex="0"` lacked visual focus indicators, making keyboard navigation difficult for users relying on it.
📸 Before/After: Visual outline or background added to interactive elements on keyboard focus.
♿ Accessibility: Ensures WCAG compliance by providing clear visual context to keyboard users navigating through custom interactive elements.

---
*PR created automatically by Jules for task [12819686288658556862](https://jules.google.com/task/12819686288658556862) started by @ryusoh*