### PR TITLE
Palette: Add focus visible styles for keyboard navigation in dropdowns

### DIFF
--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -194,3 +194,9 @@ th.sortable[data-sort="desc"] .sort-indicator::after {
 .filter-dropdown div:hover {
   background-color: var(--hover-bg);
 }
+
+.filter-dropdown div:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+  background-color: var(--hover-bg);
+}


### PR DESCRIPTION
💡 **What**: Added `:focus-visible` styles to filter dropdown items (`.filter-dropdown div`).

🎯 **Why**: These items are explicitly made focusable (`tabIndex=0`) and have keyboard event listeners to allow keyboard users to navigate and interact with them. However, they lacked visual feedback indicating which item currently held focus. This left keyboard and screen reader users navigating blind. Adding a `:focus-visible` outline gives immediate visual context without affecting mouse interactions.

📸 **Before/After**: Tested locally with `verify_focus.py` simulating Tab presses. The outline now appears when tabbing into the filter item list, matching the primary color ring used elsewhere in the application.

♿ **Accessibility**: Directly fixes a WGAC compliance issue regarding clear focus indicators (`focus-visible`) on interactive elements.

---
*PR created automatically by Jules for task [3363994681753988219](https://jules.google.com/task/3363994681753988219) started by @ryusoh*