### PR TITLE
Palette: Add focus visible styles for keyboard navigation

### DIFF
--- a/css/container.css
+++ b/css/container.css
@@ -121,6 +121,14 @@
     border-radius: 4px; /* Slight rounding for hover state */
   }
 
+  /* Keyboard Navigation Focus */
+  .container a:focus-visible,
+  .nav-container a:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
   /* Hover Interaction */
   .container a:hover,
   .nav-container a:hover {
@@ -228,6 +236,13 @@
     color: #fff;
     transform: none; /* No scale on mobile */
     text-shadow: none;
+  }
+
+  .container a:focus-visible,
+  .nav-container a:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.8);
+    outline-offset: 2px;
+    background-color: rgba(255, 255, 255, 0.1);
   }
 
   .container .fa-chevron-right::before,


### PR DESCRIPTION
Adds a white focus outline and subtle translucent background using `:focus-visible` on the main top-right navigation links (e.g. the Home and Terminal icons). Keyboard users will now have clear visual feedback of their focus state when tabbing through the navigation interface.

---
*PR created automatically by Jules for task [18080845308219386192](https://jules.google.com/task/18080845308219386192) started by @ryusoh*