### PR TITLE
Bolt: Combine multiple .reduce() passes into single loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -64,5 +64,11 @@
 **Action:** When a function requires repeatedly checking an auxiliary array inside a hot loop, create a pre-processed `Map` grouping items by their key symbol outside the loop, reducing inner lookups from O(M) to O(K) where K is the number of splits for a single symbol (effectively O(1)).
 
 ## 2024-05-30 - [Optimize loop array copying to prevent regressions]
+
 **Learning:** Reverting to generic functionally chained arrays without object construction is not measurable performance, but correctly tracking the memory space via object instantiations inside loops with high frequencies (like charts arrays) does affect Main Thread performance.
 **Action:** When manually fusing `.map().filter()` into `for` loops, correctly memoize and limit object instantiation (like `{ ...item }`) exclusively to elements that pass the filter conditional logic, preserving both rendering performance and original side effects.
+
+## 2025-04-02 - [Combine Reduce Passes]
+
+**Learning:** Replace multiple chained `.reduce()` passes with a single O(N) `for` loop to compute multiple aggregates simultaneously, particularly in performance-critical or high-frequency calculation paths.
+**Action:** Use a single loop to calculate multiple variables directly rather than chaining array methods that traverse the array multiple times.

--- a/js/transactions/terminal.js
+++ b/js/transactions/terminal.js
@@ -425,14 +425,13 @@ async function getCompositionSnapshotLine({
         (holding) => !normalized.has(holding.ticker.toUpperCase()),
       );
       if (remainder.length > 0) {
-        const totalPercent = remainder.reduce(
-          (sum, item) => sum + item.percent,
-          0,
-        );
-        const totalAbsolute = remainder.reduce(
-          (sum, item) => sum + item.absolute,
-          0,
-        );
+        let totalPercent = 0;
+        let totalAbsolute = 0;
+        for (let i = 0; i < remainder.length; i++) {
+          const item = remainder[i];
+          totalPercent += item.percent;
+          totalAbsolute += item.absolute;
+        }
         selected.push({
           ticker: "Others",
           percent: totalPercent,
@@ -459,14 +458,13 @@ async function getCompositionSnapshotLine({
             : getHoldingAssetClass(holding.ticker) === "etf",
         );
         if (remainder.length > 0) {
-          const totalPercent = remainder.reduce(
-            (sum, item) => sum + item.percent,
-            0,
-          );
-          const totalAbsolute = remainder.reduce(
-            (sum, item) => sum + item.absolute,
-            0,
-          );
+          let totalPercent = 0;
+          let totalAbsolute = 0;
+          for (let i = 0; i < remainder.length; i++) {
+            const item = remainder[i];
+            totalPercent += item.percent;
+            totalAbsolute += item.absolute;
+          }
           selected.push({
             ticker: "Others",
             percent: totalPercent,

--- a/js/transactions/terminalStats.js
+++ b/js/transactions/terminalStats.js
@@ -714,14 +714,13 @@ export async function getDurationStatsText() {
     ]);
   }
 
-  const totalOpenShareWeight = entries.reduce(
-    (sum, entry) => sum + entry.openShares,
-    0,
-  );
-  const openShareWeightedSum = entries.reduce(
-    (sum, entry) => sum + entry.openShares * entry.avgAgeDays,
-    0,
-  );
+  let totalOpenShareWeight = 0;
+  let openShareWeightedSum = 0;
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    totalOpenShareWeight += entry.openShares;
+    openShareWeightedSum += entry.openShares * entry.avgAgeDays;
+  }
   const allDenominator = totalOpenShareWeight + totalClosedQty;
   const weightedAvgAll =
     allDenominator > 0
@@ -875,24 +874,24 @@ export async function getLifespanStatsText() {
     : "";
 
   const summaryRows = [["Snapshot Date", snapshot.dateLabel || "Latest"]];
-  const openShareSum = openEntries.reduce(
-    (sum, entry) => sum + entry.openShares,
-    0,
-  );
-  const openWeightedSpanSum = openEntries.reduce(
-    (sum, entry) => sum + entry.spanDays * entry.openShares,
-    0,
-  );
+
+  let openShareSum = 0;
+  let openWeightedSpanSum = 0;
+  for (let i = 0; i < openEntries.length; i++) {
+    const entry = openEntries[i];
+    openShareSum += entry.openShares;
+    openWeightedSpanSum += entry.spanDays * entry.openShares;
+  }
   const weightedAvgOpen =
     openShareSum > 0 ? openWeightedSpanSum / openShareSum : null;
-  const closedShareSum = closedEntries.reduce(
-    (sum, entry) => sum + entry.shares,
-    0,
-  );
-  const closedWeightedSpanSum = closedEntries.reduce(
-    (sum, entry) => sum + entry.spanDays * entry.shares,
-    0,
-  );
+
+  let closedShareSum = 0;
+  let closedWeightedSpanSum = 0;
+  for (let i = 0; i < closedEntries.length; i++) {
+    const entry = closedEntries[i];
+    closedShareSum += entry.shares;
+    closedWeightedSpanSum += entry.spanDays * entry.shares;
+  }
   const weightedAvgClosed =
     closedShareSum > 0 ? closedWeightedSpanSum / closedShareSum : null;
   const combinedDenominator = openShareSum + closedShareSum;


### PR DESCRIPTION
💡 What: Replaced chained `.reduce()` passes over arrays with single O(N) `for` loops in `terminal.js` and `terminalStats.js` to compute multiple variables simultaneously.
🎯 Why: Multiple `.reduce()` calls required iterating over the same arrays multiple times, causing unnecessary CPU cycles and processing time on performance-critical paths.
📊 Impact: Eliminates redundant array traversals and reduces time complexity during terminal data processing.
🔬 Measurement: Verify changes in frontend performance during terminal operations or layout generation using Chrome DevTools Performance profiler. Ensure calculations yield correct results by running the test suite (`make check`).

---
*PR created automatically by Jules for task [2896004101078302260](https://jules.google.com/task/2896004101078302260) started by @ryusoh*