### PR TITLE
Palette: Add focus visible styles for keyboard navigation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -64,5 +64,6 @@
 **Action:** When a function requires repeatedly checking an auxiliary array inside a hot loop, create a pre-processed `Map` grouping items by their key symbol outside the loop, reducing inner lookups from O(M) to O(K) where K is the number of splits for a single symbol (effectively O(1)).
 
 ## 2024-05-30 - [Optimize loop array copying to prevent regressions]
+
 **Learning:** Reverting to generic functionally chained arrays without object construction is not measurable performance, but correctly tracking the memory space via object instantiations inside loops with high frequencies (like charts arrays) does affect Main Thread performance.
 **Action:** When manually fusing `.map().filter()` into `for` loops, correctly memoize and limit object instantiation (like `{ ...item }`) exclusively to elements that pass the filter conditional logic, preserving both rendering performance and original side effects.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2026-04-07 - Focus-Visible States for Custom Interactive Elements
+
+**Learning:** Suppressing default outlines for visual aesthetics (e.g. `outline: none;`) must always be paired with explicit `:focus-visible` rules to maintain keyboard accessibility. Elements like custom dropdown options (`.filter-dropdown div`) dynamically created by JavaScript without semantic tags lack default focus indicators and are difficult to navigate using keyboards.
+**Action:** Whenever applying `outline: none;` to an interactive element, or when creating custom interactive elements with `div` or `span`, always ensure a `:focus-visible` rule is defined using existing design tokens (like `var(--primary-color)` and `var(--hover-bg)`) to guarantee clear visual feedback during keyboard navigation.

--- a/css/container.css
+++ b/css/container.css
@@ -121,6 +121,12 @@
     border-radius: 4px; /* Slight rounding for hover state */
   }
 
+  .container a:focus-visible,
+  .nav-container a:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: -2px;
+  }
+
   /* Hover Interaction */
   .container a:hover,
   .nav-container a:hover {

--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -191,6 +191,12 @@ th.sortable[data-sort="desc"] .sort-indicator::after {
   border-radius: 4px;
 }
 
+.filter-dropdown div:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+  background-color: var(--hover-bg);
+}
+
 .filter-dropdown div:hover {
   background-color: var(--hover-bg);
 }

--- a/css/toggle.css
+++ b/css/toggle.css
@@ -57,6 +57,11 @@
   outline: none;
 }
 
+.currency-toggle:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
+}
+
 .currency-toggle.active {
   background-color: rgba(
     0,


### PR DESCRIPTION
💡 **What:** Added explicit `:focus-visible` styles to interactive components (`css/container.css`, `css/toggle.css`, `css/terminal/table.css`).
🎯 **Why:** To ensure users navigating via keyboard (e.g., using Tab) can easily identify which element currently has focus. Previous CSS patterns suppressed standard outlines (`outline: none;`) without a fallback, hindering accessibility.
📸 **Before/After:** No visual changes for mouse users. Keyboard users now see a consistent `var(--primary-color)` outline.
♿ **Accessibility:** Re-establishes a core WCAG guideline (Focus Visible 2.4.7) ensuring the current point of interest is clear for screen reader and keyboard-only users.

---
*PR created automatically by Jules for task [9538526994999826979](https://jules.google.com/task/9538526994999826979) started by @ryusoh*