### PR TITLE
Bolt: [performance improvement] Fuse map loops in chart total value and percent conversion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -67,3 +67,8 @@
 
 **Learning:** Reverting to generic functionally chained arrays without object construction is not measurable performance, but correctly tracking the memory space via object instantiations inside loops with high frequencies (like charts arrays) does affect Main Thread performance.
 **Action:** When manually fusing `.map().filter()` into `for` loops, correctly memoize and limit object instantiation (like `{ ...item }`) exclusively to elements that pass the filter conditional logic, preserving both rendering performance and original side effects.
+
+## 2025-04-09 - [Optimizing Dynamic Array allocations and Iterations]
+
+**Learning:** Allocating array iteratively and mapping it sequentially, when working with Object.entries inside loops, can easily lead to memory bloat by redundantly allocating empty arrays or mapping over the entire dimension length. Avoiding conditional Array constructions when `valueMode !== "absolute"` eliminates the allocation inside the loop entirely when disabled.
+**Action:** Always conditionally allocate arrays specifically inside iterations only if the values they capture are required. Avoid unconditional new Array(N) pre-allocations if their values can be derived lazily or discarded.

--- a/js/transactions/chart.js
+++ b/js/transactions/chart.js
@@ -4872,40 +4872,59 @@ function renderCompositionChartWithMode(ctx, chartManager, data, options = {}) {
   const rawTotalValues = Array.isArray(data.total_values)
     ? data.total_values
     : [];
-  const mappedTotalValues =
-    filteredIndices.length > 0
-      ? filteredIndices.map((index) => Number(rawTotalValues[index] ?? 0))
-      : rawTotalValues.map((value) => Number(value ?? 0));
-  const totalValuesUsd =
-    mappedTotalValues.length === dates.length
-      ? mappedTotalValues
-      : dates.map((_, idx) => Number(mappedTotalValues[idx] ?? 0));
-  const totalValuesConverted = totalValuesUsd.map((value, idx) => {
-    const converted = convertValueToCurrency(
-      value,
-      dates[idx],
-      selectedCurrency,
-    );
-    return Number.isFinite(converted) ? converted : 0;
-  });
+
+  // Bolt Optimization: Replace O(N) chained array methods with a single loop
+  // Fuses .map() calls into a single loop to avoid multiple intermediate array allocations.
+  const totalValuesConverted = new Array(dates.length);
+  if (filteredIndices.length > 0) {
+    for (let i = 0; i < dates.length; i++) {
+      const idx = filteredIndices[i];
+      const val = idx !== undefined ? Number(rawTotalValues[idx] ?? 0) : 0;
+      const converted = convertValueToCurrency(val, dates[i], selectedCurrency);
+      totalValuesConverted[i] = Number.isFinite(converted) ? converted : 0;
+    }
+  } else {
+    for (let i = 0; i < dates.length; i++) {
+      const val =
+        i < rawTotalValues.length ? Number(rawTotalValues[i] ?? 0) : 0;
+      const converted = convertValueToCurrency(val, dates[i], selectedCurrency);
+      totalValuesConverted[i] = Number.isFinite(converted) ? converted : 0;
+    }
+  }
 
   const percentSeriesMap = {};
   const chartData = {};
   Object.entries(rawSeries).forEach(([ticker, values]) => {
     const arr = Array.isArray(values) ? values : [];
-    const mappedPercent =
-      filteredIndices.length > 0
-        ? filteredIndices.map((i) => Number(arr[i] ?? 0))
-        : arr.map((value) => Number(value ?? 0));
-    const percentValues =
-      mappedPercent.length === dates.length
-        ? mappedPercent
-        : dates.map((_, idx) => Number(mappedPercent[idx] ?? 0));
+    const percentValues = new Array(dates.length);
+    let chartDataValues;
+
+    if (valueMode === "absolute") {
+      chartDataValues = new Array(dates.length);
+    }
+
+    if (filteredIndices.length > 0) {
+      for (let i = 0; i < dates.length; i++) {
+        const idx = filteredIndices[i];
+        const pct = idx !== undefined ? Number(arr[idx] ?? 0) : 0;
+        percentValues[i] = pct;
+        if (valueMode === "absolute") {
+          chartDataValues[i] = ((totalValuesConverted[i] ?? 0) * pct) / 100;
+        }
+      }
+    } else {
+      for (let i = 0; i < dates.length; i++) {
+        const pct = i < arr.length ? Number(arr[i] ?? 0) : 0;
+        percentValues[i] = pct;
+        if (valueMode === "absolute") {
+          chartDataValues[i] = ((totalValuesConverted[i] ?? 0) * pct) / 100;
+        }
+      }
+    }
+
     percentSeriesMap[ticker] = percentValues;
     if (valueMode === "absolute") {
-      chartData[ticker] = percentValues.map(
-        (pct, idx) => ((totalValuesConverted[idx] ?? 0) * pct) / 100,
-      );
+      chartData[ticker] = chartDataValues;
     } else {
       chartData[ticker] = percentValues;
     }


### PR DESCRIPTION
What: Consolidated multiple chained `.map()` calls into single `for` loops in `js/transactions/chart.js`.
Why: To eliminate redundant intermediate array allocations and reduce iteration overhead when parsing raw series and total value mappings over large dates.
Impact: Reduces heavy GC pressure and CPU execution time proportional to the number of tickers array mappings.
Measurement: Visual profiling before/after execution, or checking `dates.length` relative scaling during load.

---
*PR created automatically by Jules for task [9519161981851074736](https://jules.google.com/task/9519161981851074736) started by @ryusoh*