### PR TITLE
Bolt: Replace dual reduce calls with single loop

### DIFF
--- a/js/transactions/terminal.js
+++ b/js/transactions/terminal.js
@@ -425,14 +425,13 @@ async function getCompositionSnapshotLine({
         (holding) => !normalized.has(holding.ticker.toUpperCase()),
       );
       if (remainder.length > 0) {
-        const totalPercent = remainder.reduce(
-          (sum, item) => sum + item.percent,
-          0,
-        );
-        const totalAbsolute = remainder.reduce(
-          (sum, item) => sum + item.absolute,
-          0,
-        );
+        // Bolt: Combine multiple chained .reduce() passes into a single O(N) loop to compute percent and absolute totals simultaneously.
+        let totalPercent = 0;
+        let totalAbsolute = 0;
+        for (let i = 0; i < remainder.length; i++) {
+          totalPercent += remainder[i].percent;
+          totalAbsolute += remainder[i].absolute;
+        }
         selected.push({
           ticker: "Others",
           percent: totalPercent,
@@ -459,14 +458,13 @@ async function getCompositionSnapshotLine({
             : getHoldingAssetClass(holding.ticker) === "etf",
         );
         if (remainder.length > 0) {
-          const totalPercent = remainder.reduce(
-            (sum, item) => sum + item.percent,
-            0,
-          );
-          const totalAbsolute = remainder.reduce(
-            (sum, item) => sum + item.absolute,
-            0,
-          );
+          // Bolt: Combine multiple chained .reduce() passes into a single O(N) loop to compute percent and absolute totals simultaneously.
+          let totalPercent = 0;
+          let totalAbsolute = 0;
+          for (let i = 0; i < remainder.length; i++) {
+            totalPercent += remainder[i].percent;
+            totalAbsolute += remainder[i].absolute;
+          }
           selected.push({
             ticker: "Others",
             percent: totalPercent,


### PR DESCRIPTION
**What**: Replaced consecutive `.reduce()` array traversals with a single `for` loop in `getCompositionSnapshotLine`.
**Why**: The original implementation iterated over the `remainder` array twice to calculate `totalPercent` and `totalAbsolute`, creating unnecessary callback overhead and redundant O(N) traversals.
**Impact**: Cuts array iterations in half for the remainder calculation, reducing Garbage Collection pressure and callback allocation overhead without sacrificing readability.
**Measurement**: Verified via `make check` to ensure the mathematical output is completely identical, preserving layout logic.

---
*PR created automatically by Jules for task [15052996482606974148](https://jules.google.com/task/15052996482606974148) started by @ryusoh*