### PR TITLE
Palette: Add focus-visible state to terminal input

### DIFF
--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,6 +66,12 @@
   overflow: hidden;
 }
 
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .terminal-crosshair-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
💡 What: Added a `:focus-visible` styling to the `.terminal-input` class to display a 2px primary-colored outline. Also added a journal entry logging this UX improvement pattern.
🎯 Why: The terminal input stripped default outlines (`outline: none`), meaning keyboard-only users could easily lose track of focus while tabbing through the page. The new pseudo-class restores this essential visual feedback for keyboard users without affecting pointer navigation.
♿ Accessibility: Improves keyboard navigation support (focus states).

---
*PR created automatically by Jules for task [9403104858166116548](https://jules.google.com/task/9403104858166116548) started by @ryusoh*