### PR TITLE
Bolt: Combine multiple filter passes into single O(N) loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,3 +77,7 @@
 
 **Learning:** Re-instantiating `cumulativeValues` using `.map()` on every single ticker iteration during the `renderCompositionChartWithMode` Canvas render frame creates tremendous Garbage Collection pressure. For a chart with 100 tickers and 500 dates, `cumulativeValues = cumulativeValues.map(...)` instantiates 100 arrays of 500 items on _every single frame_ the chart renders, leading to heavy GC stalls.
 **Action:** When calculating running totals inside rendering loops or hot paths, mutate the accumulator arrays in-place using a single O(N) `for` loop instead of creating entirely new array references.
+## 2025-05-18 - [Optimizing Hot Path Filters in Table Render Loops]
+
+**Learning:** Chaining `.filter()` array methods to process search and command-palette tokens in a table render loop (`filterAndSort` in `js/transactions/table.js`) creates significant Garbage Collection pressure and slows down layout calculations due to intermediate array allocations on every pass. For large datasets with frequent user input, this causes main-thread blocking and UI jank.
+**Action:** Replace `O(N)` chained filter array passes with a single `for` loop. Apply the filter conditionals with early `continue` statements to bypass items, only pushing to the final result array once, which prevents intermediate array instantiations and minimizes overhead.

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -253,30 +253,16 @@ function filterAndSort(searchTerm = "") {
     typeof searchTerm === "string" ? searchTerm.trim() : getActiveFilterTerm();
   setActiveFilterTerm(normalizedSearchTerm);
 
-  let filtered = [...transactionState.allTransactions];
   const currentCurrency = transactionState.selectedCurrency;
   const range = transactionState.chartDateRange || { from: null, to: null };
   const rangeStart = range.from ? Date.parse(range.from) : null;
   const rangeEnd = range.to ? Date.parse(range.to) : null;
   const shouldApplyDateRange = isTransactionTableVisible();
-  if (shouldApplyDateRange && (rangeStart !== null || rangeEnd !== null)) {
-    filtered = filtered.filter((transaction) => {
-      const normalized = normalizeDateOnly(transaction.tradeDate);
-      const tradeTime = Date.parse(normalized || transaction.tradeDate);
-      if (!Number.isFinite(tradeTime)) {
-        return false;
-      }
-      if (rangeStart !== null && tradeTime < rangeStart) {
-        return false;
-      }
-      if (rangeEnd !== null && tradeTime > rangeEnd) {
-        return false;
-      }
-      return true;
-    });
-  }
 
   let parsedCommands = { assetClass: null };
+  let term = "";
+  let upcaseSecurity = null;
+  let multiTickerSet = null;
 
   if (normalizedSearchTerm) {
     const parsed = parseCommandPalette(normalizedSearchTerm);
@@ -285,68 +271,85 @@ function filterAndSort(searchTerm = "") {
       ? parsed.commands.tickers
       : deriveCompositionTickerFilters(parsed.text, parsed.commands);
     setCompositionFilterTickers(compositionFilters);
-    const term = parsed.text.toLowerCase();
+    term = parsed.text.toLowerCase();
 
-    const upcaseSecurity = parsed.commands.security
+    upcaseSecurity = parsed.commands.security
       ? normalizeTickerToken(parsed.commands.security) ||
         parsed.commands.security.toUpperCase()
       : null;
-    const multiTickerSet =
+    multiTickerSet =
       parsed.commands.tickers.length > 0
         ? new Set(parsed.commands.tickers)
         : null;
-
-    if (upcaseSecurity || multiTickerSet) {
-      filtered = filtered.filter((t) => {
-        const normalizedParams = normalizeTickerToken(t.security);
-        const ticker = normalizedParams || t.security.toUpperCase();
-
-        if (upcaseSecurity && ticker === upcaseSecurity) {
-          return true;
-        }
-        if (multiTickerSet && multiTickerSet.has(ticker)) {
-          return true;
-        }
-        return false;
-      });
-    }
-    if (parsed.commands.type) {
-      filtered = filtered.filter(
-        (t) => t.orderType.toLowerCase() === parsed.commands.type.toLowerCase(),
-      );
-    }
-    if (parsed.commands.min !== null && !Number.isNaN(parsed.commands.min)) {
-      filtered = filtered.filter(
-        (t) =>
-          Math.abs(
-            convertValueToCurrency(t.netAmount, t.tradeDate, currentCurrency),
-          ) >= parsed.commands.min,
-      );
-    }
-    if (parsed.commands.max !== null && !Number.isNaN(parsed.commands.max)) {
-      filtered = filtered.filter(
-        (t) =>
-          Math.abs(
-            convertValueToCurrency(t.netAmount, t.tradeDate, currentCurrency),
-          ) <= parsed.commands.max,
-      );
-    }
-    if (parsed.commands.assetClass) {
-      filtered = filtered.filter((t) =>
-        matchesAssetClass(t.security, parsed.commands.assetClass),
-      );
-    }
-    if (term) {
-      filtered = filtered.filter(
-        (t) =>
-          t.security.toLowerCase().includes(term) ||
-          t.orderType.toLowerCase().includes(term) ||
-          t.tradeDate.includes(term),
-      );
-    }
   } else {
     setCompositionFilterTickers([]);
     setCompositionAssetClassFilter(null);
+  }
+
+  // Bolt: Use a single O(N) loop to process all filters to prevent
+  // intermediate array allocations and reduce GC pressure.
+  const filtered = [];
+  const allTx = transactionState.allTransactions;
+  for (let i = 0; i < allTx.length; i++) {
+    const t = allTx[i];
+
+    if (shouldApplyDateRange && (rangeStart !== null || rangeEnd !== null)) {
+      const normalized = normalizeDateOnly(t.tradeDate);
+      const tradeTime = Date.parse(normalized || t.tradeDate);
+      if (!Number.isFinite(tradeTime)) continue;
+      if (rangeStart !== null && tradeTime < rangeStart) continue;
+      if (rangeEnd !== null && tradeTime > rangeEnd) continue;
+    }
+
+    if (normalizedSearchTerm) {
+      if (upcaseSecurity || multiTickerSet) {
+        const normalizedParams = normalizeTickerToken(t.security);
+        const ticker = normalizedParams || t.security.toUpperCase();
+        let matchesTicker = false;
+        if (upcaseSecurity && ticker === upcaseSecurity) {
+          matchesTicker = true;
+        } else if (multiTickerSet && multiTickerSet.has(ticker)) {
+          matchesTicker = true;
+        }
+        if (!matchesTicker) continue;
+      }
+
+      if (parsedCommands.type) {
+        if (t.orderType.toLowerCase() !== parsedCommands.type.toLowerCase()) continue;
+      }
+
+      if (parsedCommands.min !== null && !Number.isNaN(parsedCommands.min)) {
+        if (
+          Math.abs(
+            convertValueToCurrency(t.netAmount, t.tradeDate, currentCurrency),
+          ) < parsedCommands.min
+        ) continue;
+      }
+
+      if (parsedCommands.max !== null && !Number.isNaN(parsedCommands.max)) {
+        if (
+          Math.abs(
+            convertValueToCurrency(t.netAmount, t.tradeDate, currentCurrency),
+          ) > parsedCommands.max
+        ) continue;
+      }
+
+      if (parsedCommands.assetClass) {
+        if (!matchesAssetClass(t.security, parsedCommands.assetClass)) continue;
+      }
+
+      if (term) {
+        if (
+          !(
+            t.security.toLowerCase().includes(term) ||
+            t.orderType.toLowerCase().includes(term) ||
+            t.tradeDate.includes(term)
+          )
+        ) continue;
+      }
+    }
+
+    filtered.push(t);
   }
 
   setCompositionAssetClassFilter(parsedCommands.assetClass || null);


### PR DESCRIPTION
💡 What: The multiple chained `.filter()` array methods in `filterAndSort` within `js/transactions/table.js` were refactored into a single O(N) `for` loop. The filter conditions were inverted using early `continue` statements to bypass items efficiently.
🎯 Why: Chaining array methods like `.filter()` causes intermediate arrays to be created and discarded on every pass, which adds significant memory and Garbage Collection (GC) overhead inside high-frequency render or filter functions.
📊 Impact: Eliminates multiple array allocations per `filterAndSort` execution, reducing GC pressure and blocking of the main thread when updating the transaction table.
🔬 Measurement: Verified the optimization works as expected by running `pnpm test` and `pnpm lint`. The performance improvement can be measured by profiling memory allocation and observing less GC activity when heavily typing inside the transaction search box or toggling filters.

---
*PR created automatically by Jules for task [15657315339948506713](https://jules.google.com/task/15657315339948506713) started by @ryusoh*