### PR TITLE
Palette: Add keyboard focus-visible states for accessible navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2025-05-18 - Restoring Keyboard Focus When Removing Outlines
+
+**Learning:** When custom styling input fields or navigation buttons requires removing the default browser focus ring (`outline: none`), it severely degrades keyboard accessibility by removing the visible focus state for keyboard users.
+**Action:** Whenever `outline: none` or similar properties are used to hide default focus rings, always restore keyboard accessibility by adding a `:focus-visible` pseudo-class with a distinct custom outline (e.g., `var(--primary-color)`) so keyboard users can perceive focus without affecting the aesthetics for mouse users.

--- a/awesome_tts/awesometts/service/sapi5js.js
+++ b/awesome_tts/awesometts/service/sapi5js.js
@@ -157,12 +157,16 @@ if (command === "voice-list") {
     var name;
     try {
       name = voices.item(i).getAttribute("name");
-    } catch (e) { WScript.echo("Warning: Attribute extraction failed: " + e.message); }
+    } catch (e) {
+      WScript.echo("Warning: Attribute extraction failed: " + e.message);
+    }
 
     var language;
     try {
       language = voices.item(i).getAttribute("language");
-    } catch (e) { WScript.echo("Warning: Attribute extraction failed: " + e.message); }
+    } catch (e) {
+      WScript.echo("Warning: Attribute extraction failed: " + e.message);
+    }
 
     if (typeof name == "string" && name.length > 0) {
       WScript.echo(

--- a/css/container.css
+++ b/css/container.css
@@ -47,6 +47,13 @@
   outline: none;
 }
 
+.container a:focus-visible,
+.nav-container a:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 /* =========================================
    Desktop Styles (Min-Width: 769px)
    The Floating Vertical Glass Dock

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,11 +66,18 @@
   overflow: hidden;
 }
 
-.terminal-input:focus,
-.terminal-input:focus-visible {
+.terminal-input:focus {
   outline: none !important;
   box-shadow: none !important;
   border: none !important;
+}
+
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color) !important;
+  outline-offset: 2px;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 4px;
 }
 
 .terminal-crosshair-overlay {

--- a/css/toggle.css
+++ b/css/toggle.css
@@ -57,6 +57,12 @@
   outline: none;
 }
 
+.currency-toggle:focus-visible {
+  outline: 2px solid var(--primary-color);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .currency-toggle.active {
   background-color: rgba(
     0,

--- a/js/utils/date.js
+++ b/js/utils/date.js
@@ -81,7 +81,9 @@ export function isGoodFriday(date) {
     easterDate.getTime() - 2 * 24 * 60 * 60 * 1000,
   );
 
-  return month === goodFridayDate.getMonth() && day === goodFridayDate.getDate();
+  return (
+    month === goodFridayDate.getMonth() && day === goodFridayDate.getDate()
+  );
 }
 
 /**


### PR DESCRIPTION
**💡 What:**
Added `:focus-visible` pseudo-class styles to interactive elements (`terminal-input`, `.container a`, `.nav-container a`, `.currency-toggle`) that previously had `outline: none`. This creates a prominent, themed outline (using `--primary-color`) only when users navigate using the keyboard.

**🎯 Why:**
Removing default focus rings via `outline: none` completely hides focus state for keyboard users, a critical accessibility barrier. Implementing `:focus-visible` ensures keyboard users can easily track their active element while mouse interactions do not trigger the outline.

**📸 Before/After:**
*(See Playwright verification screenshots)*
- **Before:** Tabbing to terminal inputs, nav links, or currency toggles provided zero visual feedback.
- **After:** Tabbing to these elements displays a distinct 2px solid primary color outline.

**♿ Accessibility:**
Dramatically improves keyboard navigation by providing clear, visible focus indicators without disrupting the visual design for pointer device users.

---
*PR created automatically by Jules for task [9183514858384935405](https://jules.google.com/task/9183514858384935405) started by @ryusoh*