### PR TITLE
Sentinel: [MEDIUM] Fix missing timeout on external API calls

### DIFF
--- a/awesome_tts/awesometts/service/googletts.py
+++ b/awesome_tts/awesometts/service/googletts.py
@@ -181,7 +181,7 @@ class GoogleTTS(Service):
             if options['profile'] != 'default':
                 payload["audioConfig"]["effectsProfileId"] = [options['profile']]
 
-            r = requests.post("https://texttospeech.googleapis.com/v1/text:synthesize?key={}".format(options['key']), headers=headers, json=payload)
+            r = requests.post("https://texttospeech.googleapis.com/v1/text:synthesize?key={}".format(options['key']), headers=headers, json=payload, timeout=10)
             r.raise_for_status()
 
             data = r.json()


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing timeout parameter on the `requests.post` call for the Google Cloud Text-to-Speech API in `awesome_tts/awesometts/service/googletts.py`.
🎯 **Impact:** An unresponsive or slow external Google server could cause the add-on to hang indefinitely, blocking Anki's main thread or exhausting resources, creating a localized Denial of Service condition.
🔧 **Fix:** Added a `timeout=10` parameter to the `requests.post` call to ensure the request fails securely after a reasonable timeframe if there is no response.
✅ **Verification:** Verified by running Python unit tests via `make check-py`, which continue to pass successfully.

---
*PR created automatically by Jules for task [2248520675545766306](https://jules.google.com/task/2248520675545766306) started by @ryusoh*