### PR TITLE
Bolt: optimize array chained iterations with single O(N) loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,7 +77,13 @@
 
 **Learning:** Re-instantiating `cumulativeValues` using `.map()` on every single ticker iteration during the `renderCompositionChartWithMode` Canvas render frame creates tremendous Garbage Collection pressure. For a chart with 100 tickers and 500 dates, `cumulativeValues = cumulativeValues.map(...)` instantiates 100 arrays of 500 items on _every single frame_ the chart renders, leading to heavy GC stalls.
 **Action:** When calculating running totals inside rendering loops or hot paths, mutate the accumulator arrays in-place using a single O(N) `for` loop instead of creating entirely new array references.
+
 ## 2025-05-18 - [Optimizing Hot Path Filters in Table Render Loops]
 
 **Learning:** Chaining `.filter()` array methods to process search and command-palette tokens in a table render loop (`filterAndSort` in `js/transactions/table.js`) creates significant Garbage Collection pressure and slows down layout calculations due to intermediate array allocations on every pass. For large datasets with frequent user input, this causes main-thread blocking and UI jank.
 **Action:** Replace `O(N)` chained filter array passes with a single `for` loop. Apply the filter conditionals with early `continue` statements to bypass items, only pushing to the final result array once, which prevents intermediate array instantiations and minimizes overhead.
+
+## 2025-05-20 - [Optimizing Metric Aggregation with Single Loop Passes]
+
+**Learning:** Utilizing chained array methods such as `.map().filter().sort().reduce()` (as found in utility functions like `computeWeightedMedian` or when assembling `buildPortfolioConfig` inputs) to process thousands of inputs creates severe array allocations inside frequently-rendered modules. The chained iteration creates O(k*N) complexity and significantly taxes the browser's Garbage Collection pipeline over each consecutive array instantiation.
+**Action:** Refactor sequential map-filter-reduce iterations into a single O(N) `for` loop. Perform the conditional validations and mapping extractions inline, accumulate aggregates simultaneously, and sort only the minimal viable valid subset array right before returning, eliminating all intermediate allocation arrays.

--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -421,16 +421,17 @@ function computeMetrics(config) {
   const exitYear = computeExitYear(config, horizon);
   const sharesOutstanding = getSharesOutstanding(config);
 
-  const normalizedScenarios = scenarios.map((scenario) =>
-    normalizeScenario(scenario),
-  );
-  const outcomes = normalizedScenarios.map((scenario) =>
-    computeScenarioOutcome(scenario, { price, eps, horizon }),
-  );
-  const expectedMultiple = outcomes.reduce(
-    (sum, outcome) => sum + outcome.prob * outcome.multiple,
-    0,
-  );
+  const normalizedScenarios = [];
+  const outcomes = [];
+  let expectedMultiple = 0;
+
+  for (let i = 0; i < scenarios.length; i++) {
+    const norm = normalizeScenario(scenarios[i]);
+    normalizedScenarios.push(norm);
+    const outcome = computeScenarioOutcome(norm, { price, eps, horizon });
+    outcomes.push(outcome);
+    expectedMultiple += outcome.prob * outcome.multiple;
+  }
   const expectedCagr =
     expectedMultiple > 0 ? expectedMultiple ** (1 / horizon) - 1 : 0;
   const edge = expectedCagr - benchmark;
@@ -961,25 +962,29 @@ function buildPortfolioConfig(configs) {
   if (!(totalValue > 0)) {
     return null;
   }
-  const weighted = (selector) =>
-    configs.reduce((sum, cfg) => sum + cfg.weight * selector(cfg), 0);
   const basePreferences = getPreferences(configs[0]);
   const horizonRaw = Number(basePreferences.horizon ?? 1);
   const horizon =
     Number.isFinite(horizonRaw) && horizonRaw > 0 ? horizonRaw : 1;
   const price = totalValue;
   const eps = 1;
-  const benchmarkValue = weighted(
-    (cfg) => getBenchmarkDescriptor(getPreferences(cfg)).value,
-  );
-  const kellyScale = weighted((cfg) => getPreferences(cfg).kellyScale ?? 0.5);
-  const targetCagr = weighted((cfg) => getPreferences(cfg).targetCagr ?? 0.1);
-  const volatility = Math.sqrt(
-    configs.reduce((sum, cfg) => {
-      const vol = getEffectiveVolatility(cfg);
-      return sum + Math.pow(cfg.weight, 2) * Math.pow(vol, 2);
-    }, 0),
-  );
+
+  let benchmarkValue = 0;
+  let kellyScale = 0;
+  let targetCagr = 0;
+  let volSum = 0;
+
+  for (let i = 0; i < configs.length; i++) {
+    const cfg = configs[i];
+    const w = cfg.weight;
+    const prefs = getPreferences(cfg);
+    benchmarkValue += w * getBenchmarkDescriptor(prefs).value;
+    kellyScale += w * (prefs.kellyScale ?? 0.5);
+    targetCagr += w * (prefs.targetCagr ?? 0.1);
+    const vol = getEffectiveVolatility(cfg);
+    volSum += w * w * vol * vol;
+  }
+  const volatility = Math.sqrt(volSum);
   const overrides = {
     price,
     eps,

--- a/js/transactions/terminalStats.js
+++ b/js/transactions/terminalStats.js
@@ -1143,19 +1143,19 @@ function formatYearsValue(days) {
 }
 
 function computeWeightedMedian(entries, weightGetter, valueGetter) {
-  const normalized = entries
-    .map((entry) => {
-      const weight = weightGetter(entry);
-      const value = valueGetter(entry);
-      if (!Number.isFinite(weight) || weight <= 0 || !Number.isFinite(value)) {
-        return null;
-      }
-      return { weight, value };
-    })
-    .filter(Boolean)
-    .sort((a, b) => a.value - b.value);
+  const normalized = [];
+  let totalWeight = 0;
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const weight = weightGetter(entry);
+    const value = valueGetter(entry);
+    if (Number.isFinite(weight) && weight > 0 && Number.isFinite(value)) {
+      normalized.push({ weight, value });
+      totalWeight += weight;
+    }
+  }
+  normalized.sort((a, b) => a.value - b.value);
 
-  const totalWeight = normalized.reduce((sum, item) => sum + item.weight, 0);
   if (totalWeight <= 0) {
     return null;
   }


### PR DESCRIPTION
Replaced multiple chained array methods (`.reduce()` and `.map().filter()`) inside frontend charting evaluation logic with single O(N) `for` loop passes.

This prevents creating severe array allocations during calculation logic for `buildPortfolioConfig` and `computeWeightedMedian`, significantly reducing GC pressure.

Also added documentation reflecting the optimizations into `.jules/bolt.md`.

---
*PR created automatically by Jules for task [15261736233807002930](https://jules.google.com/task/15261736233807002930) started by @ryusoh*