### PR TITLE
Palette: Add focus visible styles to dropdown menu

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -77,6 +77,7 @@
 
 **Learning:** Re-instantiating `cumulativeValues` using `.map()` on every single ticker iteration during the `renderCompositionChartWithMode` Canvas render frame creates tremendous Garbage Collection pressure. For a chart with 100 tickers and 500 dates, `cumulativeValues = cumulativeValues.map(...)` instantiates 100 arrays of 500 items on _every single frame_ the chart renders, leading to heavy GC stalls.
 **Action:** When calculating running totals inside rendering loops or hot paths, mutate the accumulator arrays in-place using a single O(N) `for` loop instead of creating entirely new array references.
+
 ## 2025-05-18 - [Optimizing Hot Path Filters in Table Render Loops]
 
 **Learning:** Chaining `.filter()` array methods to process search and command-palette tokens in a table render loop (`filterAndSort` in `js/transactions/table.js`) creates significant Garbage Collection pressure and slows down layout calculations due to intermediate array allocations on every pass. For large datasets with frequent user input, this causes main-thread blocking and UI jank.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2025-03-24 - Focus Visibility for Dynamically Generated Components
+
+**Learning:** When generating custom UI components like dropdown menus via JavaScript, elements configured to receive focus using `tabindex="0"` will lack visual indications of focus by default unless styling rules explicitly handle it. This degrades keyboard accessibility for users expecting visual feedback.
+**Action:** When adding `tabindex="0"` to custom interactive components, always include equivalent `:focus-visible` CSS rules, reusing existing hover states and global outline tokens (like `var(--primary-color)`) to guarantee clear visual focus.

--- a/css/terminal/table.css
+++ b/css/terminal/table.css
@@ -191,6 +191,9 @@ th.sortable[data-sort="desc"] .sort-indicator::after {
   border-radius: 4px;
 }
 
-.filter-dropdown div:hover {
+.filter-dropdown div:hover,
+.filter-dropdown div:focus-visible {
   background-color: var(--hover-bg);
+  outline: 2px solid var(--primary-color);
+  outline-offset: -2px;
 }


### PR DESCRIPTION
Added `:focus-visible` styles to `.filter-dropdown div` elements using existing design tokens (`--primary-color`, `--hover-bg`) to ensure keyboard accessibility. Logged UX learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [18415637765650332974](https://jules.google.com/task/18415637765650332974) started by @ryusoh*