### PR TITLE
Palette: Add focus-visible outline for terminal input keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2024-04-14 - Custom Styling Focus States
+
+**Learning:** When custom styling input fields (like terminal emulators) requires removing default browser outlines (`outline: none`), it breaks keyboard accessibility if not handled properly.
+**Action:** Always restore keyboard accessibility by adding a `:focus-visible` pseudo-class with a distinct outline (e.g., `var(--primary-color)`) so keyboard users can perceive focus without affecting mouse users.

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,9 +66,15 @@
   overflow: hidden;
 }
 
-.terminal-input:focus,
-.terminal-input:focus-visible {
+.terminal-input:focus {
   outline: none !important;
+  box-shadow: none !important;
+  border: none !important;
+}
+
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color) !important;
+  outline-offset: 2px;
   box-shadow: none !important;
   border: none !important;
 }


### PR DESCRIPTION
This PR addresses an accessibility issue where the terminal input lacked any visual focus indicator when navigated via keyboard.

**What:**
Separated the `:focus` and `:focus-visible` pseudo-classes for the `.terminal-input`.

**Why:**
Previously, both `:focus` and `:focus-visible` had `outline: none`, meaning users navigating with the `Tab` key could not perceive when the terminal input received focus. By explicitly defining `:focus-visible` with a `2px solid var(--primary-color)` outline, we restore critical keyboard accessibility while maintaining the clean, outline-free aesthetic for users who click the input with a mouse (`:focus`).

**Accessibility:**
- Keyboard users can now clearly see when the terminal input is focused.

A journal entry has also been added to `.jules/palette.md` to document this learning.

---
*PR created automatically by Jules for task [13309820135011766246](https://jules.google.com/task/13309820135011766246) started by @ryusoh*