### PR TITLE
Sentinel: Remove unsafe innerHTML assignments from terminal UI and command handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -95,3 +95,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Found `exec()` being used in `awesome_tts/awesometts/languagetools.py` to evaluate base64-encoded strings imported from an obfuscated `trial.py` module.
 **Learning:** This obfuscated approach was used for loading `py-machineid` logic to fingerprint hosts securely, but utilizing `exec()` introduces significant remote code execution (RCE) and code injection risks, while heavily diminishing code readability and audibility.
 **Prevention:** Avoid `exec()` unconditionally. Replace such obfuscation layers with directly imported code. In this case, I created a safe, de-obfuscated `machineid.py` and computed the HMAC directly to remove all base64+exec vulnerabilities.
+
+## 2024-05-31 - Prevent DOM-based XSS by removing `innerHTML` in chart cleanup and terminal reset
+
+**Vulnerability:** Emptying DOM elements using `element.innerHTML = ""` in `js/terminal.js` and `js/commands/handler.js` to clear output.
+**Learning:** While assigning an empty string to `innerHTML` is not actively exploitable as an XSS vector itself, retaining `.innerHTML` setters in the codebase violates strict defense-in-depth secure coding standards. It trains developers to reach for unsafe DOM manipulation APIs, keeps the codebase non-compliant with modern SAST linters (like `no-inner-html`), and risks accidental introduction of XSS if the string assignment is later modified to include untrusted variables.
+**Prevention:** Always use safe DOM APIs like `element.textContent = ""` or `element.replaceChildren()` when clearing element contents to maintain robust defense-in-depth and avoid security regressions.

--- a/js/commands/handler.js
+++ b/js/commands/handler.js
@@ -70,7 +70,7 @@ export function clearCurrentChart() {
   }
 
   if (legend) {
-    legend.innerHTML = "";
+    legend.textContent = "";
     legend.style.display = "none";
   }
 

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -48,7 +48,7 @@ function printPrompt(command) {
 function clearTerminal() {
   const terminalOutput = document.getElementById("terminalOutput");
   if (terminalOutput) {
-    terminalOutput.innerHTML = "";
+    terminalOutput.textContent = "";
   }
 }
 


### PR DESCRIPTION
🚨 **Severity:** LOW (Defense-in-depth / SAST Compliance)
💡 **Vulnerability:** `element.innerHTML = ""` was being used to clear elements in `js/terminal.js` and `js/commands/handler.js`. While assigning an empty string isn't inherently exploitable, retaining `.innerHTML` setters violates secure coding standards, triggers SAST linting rules (e.g., `no-inner-html`), and introduces risk if future changes dynamically interpolate data into those setters.
🎯 **Impact:** Prevents accidental XSS regressions by future developers and standardizes safe DOM manipulation APIs.
🔧 **Fix:** Replaced `terminalOutput.innerHTML = ""` with `terminalOutput.textContent = ""` and `legend.innerHTML = ""` with `legend.textContent = ""`.
✅ **Verification:** Ran `make check-node` and `make check-py` to ensure tests passed. 

Logged findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14850442503624355337](https://jules.google.com/task/14850442503624355337) started by @ryusoh*