### PR TITLE
Palette: Add keyboard focus outline to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2026-04-15 - Terminal Input Focus Visibility
+
+**Learning:** When custom styling input fields (like terminal emulators) requires removing default browser outlines (`outline: none`), it breaks keyboard navigation as users cannot see when the input is focused.
+**Action:** Always restore keyboard accessibility by adding a `:focus-visible` pseudo-class with a distinct outline (e.g., `var(--primary-color)`) so keyboard users can perceive focus without affecting mouse users.

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,9 +66,15 @@
   overflow: hidden;
 }
 
-.terminal-input:focus,
-.terminal-input:focus-visible {
+.terminal-input:focus {
   outline: none !important;
+  box-shadow: none !important;
+  border: none !important;
+}
+
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color) !important;
+  outline-offset: 2px;
   box-shadow: none !important;
   border: none !important;
 }


### PR DESCRIPTION
## 💡 What:
Added a `:focus-visible` CSS pseudo-class rule for the `.terminal-input` in `css/terminal/terminal.css`. This separates mouse focus (which remains outline-free) from keyboard focus, which now receives a `2px solid var(--primary-color)` outline.

## 🎯 Why:
Previously, `.terminal-input` had `outline: none !important;` globally. This completely removed focus indicators for keyboard users navigating to the terminal input, making it difficult or impossible to determine if the input was active. This micro-UX improvement ensures visual feedback without disrupting the existing mouse-click experience.

## ♿ Accessibility:
Improves keyboard accessibility by restoring a visible focus indicator using standard design tokens, adhering to WCAG focus visibility guidelines. Also documented this pattern in `.jules/palette.md`.

---
*PR created automatically by Jules for task [10717768459799919065](https://jules.google.com/task/10717768459799919065) started by @ryusoh*