### PR TITLE
Sentinel: [security improvement] Remove innerHTML clearing in terminal

### DIFF
--- a/js/transactions/terminal.js
+++ b/js/transactions/terminal.js
@@ -642,7 +642,7 @@ export function updateTerminalCrosshair(snapshot, rangeSummary) {
   if (details.range) {
     if (!rangeSummary) {
       details.range.hidden = true;
-      details.range.innerHTML = "";
+      details.range.textContent = "";
     } else {
       const durationLabel =
         rangeSummary.durationDays >= 1
@@ -1253,7 +1253,7 @@ export function initTerminal({
         requestFadeUpdate();
         break;
       case "clear":
-        outputContainer.innerHTML = "";
+        outputContainer.textContent = "";
         closeAllFilterDropdowns();
         resetSortState();
         setChartDateRange({ from: null, to: null }); // Reset date range


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Remove innerHTML clearing in terminal

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Emptying DOM elements using `element.innerHTML = ""` was being used in `js/transactions/terminal.js` to clear output. While assigning an empty string is not actively exploitable as an XSS vector itself, retaining `.innerHTML` setters in the codebase violates strict defense-in-depth secure coding standards. It trains developers to reach for unsafe DOM manipulation APIs, keeps the codebase non-compliant with modern SAST linters, and risks accidental introduction of XSS if the string assignment is later modified to include untrusted variables.
🎯 **Impact:** Prevents potential DOM-based XSS and trains better coding practices. 
🔧 **Fix:** Replaced `.innerHTML = ""` with safer DOM methods like `.textContent = ""` to clear element contents.
✅ **Verification:** Ran Node.js test suite and linter. No regressions were found.

---
*PR created automatically by Jules for task [3856325720073570986](https://jules.google.com/task/3856325720073570986) started by @ryusoh*