### PR TITLE
Palette: Restore keyboard focus for terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2026-04-16 - Terminal Input Focus Rings
+
+**Learning:** When custom styling text inputs (like in terminal emulators), developers often remove the default browser outline (`outline: none`) to achieve a specific aesthetic. If this is done globally for all focus states, it destroys keyboard accessibility, preventing users from seeing where their focus is.
+**Action:** When removing default browser outlines, always separate mouse focus from keyboard focus. Keep `:focus { outline: none; }` for mouse interactions if desired, but explicitly restore visibility using the `:focus-visible` pseudo-class with a distinct outline (e.g., `outline: 2px solid var(--primary-color)`) so keyboard users can navigate effectively.

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,11 +66,17 @@
   overflow: hidden;
 }
 
-.terminal-input:focus,
-.terminal-input:focus-visible {
+.terminal-input:focus {
   outline: none !important;
   box-shadow: none !important;
   border: none !important;
+}
+
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color) !important;
+  box-shadow: none !important;
+  border: none !important;
+  border-radius: 2px;
 }
 
 .terminal-crosshair-overlay {


### PR DESCRIPTION
💡 What: Restored the keyboard focus indicator (`:focus-visible`) for the terminal input by separating mouse `:focus` from keyboard `:focus-visible` and applying the `--primary-color` outline.
🎯 Why: Previously, `.terminal-input` entirely suppressed outlines across all focus states, making it impossible for keyboard users navigating via Tab to visually see when the terminal prompt received focus.
♿ Accessibility: Restores basic WCAG keyboard focus visibility requirements while preserving the intended visual aesthetic for mouse users.

---
*PR created automatically by Jules for task [17040239249997342363](https://jules.google.com/task/17040239249997342363) started by @ryusoh*