### PR TITLE
Add missing test coverage for Python data scripts

### DIFF
--- a/data/anki/tests/test_calculate_future_due.py
+++ b/data/anki/tests/test_calculate_future_due.py
@@ -1,11 +1,13 @@
 import pytest
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 # Add parent to sys.path so we can import the modules
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from generate_custom_stats import calculate_future_due
+import generate_custom_stats
 
 def test_calculate_future_due_basic():
     """Test with a mix of mature and young cards."""
@@ -104,13 +106,13 @@ def test_calculate_future_due_auto_max_days():
     assert result[2]["day"] == 2
     assert result[2]["mature"] == 1
 
-def test_calculate_future_due_fallback_today(monkeypatch):
+def test_calculate_future_due_fallback_today():
     """Test that it falls back to get_anki_today() if anki_today is None."""
-    monkeypatch.setattr("generate_custom_stats.get_anki_today", lambda: 500)
-    cards_data = [{"id": 1, "due": 500, "ivl": 10, "queue": 2}]
-    result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=None)
-    assert len(result) == 1
-    assert result[0] == {"day": 0, "mature": 0, "young": 1}
+    with patch.object(generate_custom_stats, 'get_anki_today', return_value=500):
+        cards_data = [{"id": 1, "due": 500, "ivl": 10, "queue": 2}]
+        result, result_by_deck = calculate_future_due(cards_data, cid_to_deck={}, max_days=1, anki_today=None)
+        assert len(result) == 1
+        assert result[0] == {"day": 0, "mature": 0, "young": 1}
 
 def test_calculate_future_due_by_deck():
     """Test that result_by_deck correctly splits data by deck."""
@@ -193,23 +195,23 @@ def test_calculate_future_due_missing_keys():
     assert "C" not in result_by_deck
 
 
-def test_calculate_future_due_all_overdue_auto_max_days(monkeypatch):
+def test_calculate_future_due_all_overdue_auto_max_days():
     """Test when max_days=None and all review cards are overdue."""
-    monkeypatch.setattr("generate_custom_stats.get_anki_today", lambda: 100)
-    cards_data = [
-        {"id": 1, "due": 95, "ivl": 21, "queue": 2}, # Overdue
-        {"id": 2, "due": 98, "ivl": 10, "queue": 2}, # Overdue
-    ]
-    result, result_by_deck = calculate_future_due(cards_data, max_days=None)
-    assert result == []
-    assert result_by_deck == {}
+    with patch.object(generate_custom_stats, 'get_anki_today', return_value=100):
+        cards_data = [
+            {"id": 1, "due": 95, "ivl": 21, "queue": 2}, # Overdue
+            {"id": 2, "due": 98, "ivl": 10, "queue": 2}, # Overdue
+        ]
+        result, result_by_deck = calculate_future_due(cards_data, max_days=None)
+        assert result == []
+        assert result_by_deck == {}
 
-def test_calculate_future_due_negative_max_days(monkeypatch):
+def test_calculate_future_due_negative_max_days():
     """Test explicitly passing a negative max_days."""
-    monkeypatch.setattr("generate_custom_stats.get_anki_today", lambda: 100)
-    cards_data = [
-        {"id": 1, "due": 105, "ivl": 21, "queue": 2},
-    ]
-    result, result_by_deck = calculate_future_due(cards_data, max_days=-5)
-    assert result == []
-    assert result_by_deck == {}
+    with patch.object(generate_custom_stats, 'get_anki_today', return_value=100):
+        cards_data = [
+            {"id": 1, "due": 105, "ivl": 21, "queue": 2},
+        ]
+        result, result_by_deck = calculate_future_due(cards_data, max_days=-5)
+        assert result == []
+        assert result_by_deck == {}

--- a/data/anki/tests/test_generate_custom_stats.py
+++ b/data/anki/tests/test_generate_custom_stats.py
@@ -1,0 +1,223 @@
+import pytest
+import os
+import tempfile
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import sys
+
+# Change directory and add to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("generate_custom_stats", str(Path(__file__).parent.parent / "generate_custom_stats.py"))
+generate_custom_stats = importlib.util.module_from_spec(spec)
+sys.modules["generate_custom_stats"] = generate_custom_stats
+spec.loader.exec_module(generate_custom_stats)
+
+def test_generate_custom_stats_main():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        output_file = temp_path / "custom_stats_data.json"
+        cards_file = temp_path / "cards.json.gz"
+
+        # Test 1: Files don't exist -> return False
+        with patch('generate_custom_stats.OUTPUT_FILE', output_file), \
+             patch('generate_custom_stats.CARDS_FILE', cards_file):
+            assert generate_custom_stats.main() == False
+
+        # Test 2: Invalid JSON
+        import gzip
+        with gzip.open(cards_file, 'wt') as f:
+            f.write("invalid json")
+        with patch('generate_custom_stats.OUTPUT_FILE', output_file), \
+             patch('generate_custom_stats.CARDS_FILE', cards_file):
+            with pytest.raises(json.decoder.JSONDecodeError):
+                generate_custom_stats.main()
+
+        # Test 4: Success
+        cards_data = [
+            {"id": 1, "ivl": 21, "type": 2, "queue": 2, "due": 100, "deck_name": "Default"},
+            {"id": 2, "ivl": 10, "type": 2, "queue": 2, "due": 100, "deck_name": "Default"},
+            {"id": 3, "ivl": 0, "type": 0, "queue": 1},
+        ]
+        with gzip.open(cards_file, 'wt') as f:
+            json.dump(cards_data, f)
+
+        with patch('generate_custom_stats.OUTPUT_FILE', output_file), \
+             patch('generate_custom_stats.CARDS_FILE', cards_file), \
+             patch('generate_custom_stats.get_anki_today', return_value=90), \
+             patch('generate_custom_stats.SCRIPT_DIR', temp_path):
+            assert generate_custom_stats.main() == True
+            assert output_file.exists()
+            assert (temp_path / "full_forecast.json.gz").exists()
+
+            # Second run, full forecast unchanged
+            assert generate_custom_stats.main() == True
+
+def test_calculate_future_due():
+    cards_data = [
+        # due today (0) -> bucket 0
+        {"id": 1, "queue": 2, "ivl": 25, "due": 100},
+        {"id": 2, "queue": 2, "ivl": 5, "due": 100},
+
+        # due tomorrow (1) -> bucket 1
+        {"id": 3, "queue": 2, "ivl": 21, "due": 101},
+
+        # overdue (-1) -> ignored
+        {"id": 4, "queue": 2, "ivl": 30, "due": 99},
+
+        # not review -> ignored
+        {"id": 5, "queue": 1, "ivl": 30, "due": 105},
+
+        # missing properties -> defaults -> ignored because due=0, today=100 -> negative
+        {"id": 6},
+    ]
+
+    cid_to_deck = {1: "DeckA", 2: "DeckB", 3: "DeckA", 4: "DeckB"}
+
+    global_stats, deck_stats = generate_custom_stats.calculate_future_due(cards_data, cid_to_deck, anki_today=100)
+
+    assert len(global_stats) == 2  # buckets 0 and 1
+
+    # Bucket 0: 1 mature, 1 young
+    assert global_stats[0]["mature"] == 1
+    assert global_stats[0]["young"] == 1
+
+    # Bucket 1: 1 mature, 0 young
+    assert global_stats[1]["mature"] == 1
+    assert global_stats[1]["young"] == 0
+
+    # Deck stats
+    assert len(deck_stats["DeckA"]) == 2  # Has cards in day 0 and 1
+    assert deck_stats["DeckA"][0]["mature"] == 1
+    assert deck_stats["DeckA"][1]["mature"] == 1
+
+    assert len(deck_stats["DeckB"]) == 1  # Has card only in day 0
+    assert deck_stats["DeckB"][0]["young"] == 1
+
+def test_read_existing_total():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        output_file = temp_path / "output.json"
+
+        # Missing file
+        assert generate_custom_stats._read_existing_total(output_file) == 0
+
+        # Valid file
+        with open(output_file, "w") as f:
+            json.dump({"futureDue": [{"mature": 10, "young": 5}, {"mature": 20, "young": 15}]}, f)
+        assert generate_custom_stats._read_existing_total(output_file) == 50
+
+        # Invalid file
+        with open(output_file, "w") as f:
+            f.write("invalid")
+        assert generate_custom_stats._read_existing_total(output_file) == 0
+
+def test_should_write():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        output_file = temp_path / "output.json"
+
+        new_stats = [{"mature": 50, "young": 50}] # Total 100
+
+        # No old file -> Write
+        assert generate_custom_stats._should_write(new_stats, output_file) == True
+
+        # Write valid old file smaller
+        with open(output_file, "w") as f:
+            json.dump({"futureDue": [{"mature": 5, "young": 5}]}, f)
+        assert generate_custom_stats._should_write(new_stats, output_file) == True
+
+        # Old file large, new empty -> Don't write
+        assert generate_custom_stats._should_write([], output_file) == False
+
+        # Old file large (200), new tiny (10) -> Don't write
+        with open(output_file, "w") as f:
+            json.dump({"futureDue": [{"mature": 100, "young": 100}]}, f)
+        assert generate_custom_stats._should_write([{"mature": 5, "young": 5}], output_file) == False
+
+def test_get_anki_today_with_db():
+    with tempfile.NamedTemporaryFile(suffix=".anki2", delete=False) as f:
+        db_path = f.name
+
+    try:
+        import sqlite3
+        conn = sqlite3.connect(db_path)
+        c = conn.cursor()
+        c.execute("CREATE TABLE col (crt INTEGER)")
+
+        # Set creation time to Jan 1, 2021 (timestamp 1609459200)
+        c.execute("INSERT INTO col VALUES (1609459200)")
+        conn.commit()
+        conn.close()
+
+        with patch('generate_custom_stats.find_anki_collection', return_value=Path(db_path)):
+            # We don't assert a specific value since it depends on the current date
+            today = generate_custom_stats.get_anki_today()
+            assert today > 0
+
+    finally:
+        os.unlink(db_path)
+
+def test_get_anki_today_db_error():
+    with tempfile.NamedTemporaryFile(suffix=".anki2", delete=False) as f:
+        db_path = f.name
+
+    try:
+        with patch('generate_custom_stats.find_anki_collection', return_value=Path(db_path)):
+            # Empty file, will cause sqlite error
+            today = generate_custom_stats.get_anki_today()
+            assert today > 6000 # Fallback 2007 logic
+
+    finally:
+        os.unlink(db_path)
+
+def test_find_anki_collection_mocked():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        profile_dir = temp_path / "Profile 1"
+        profile_dir.mkdir()
+        db_file = profile_dir / "collection.anki2"
+        db_file.touch()
+
+        # Override Anki2 folder location through patch
+        with patch('pathlib.Path.home') as mock_home:
+            mock_home_path = MagicMock()
+            mock_home.return_value = mock_home_path
+
+            # Setup path traversal: Path.home() / "Library" / "Application Support" / "Anki2"
+            mock_lib = MagicMock()
+            mock_app_support = MagicMock()
+            mock_anki2 = MagicMock()
+
+            mock_home_path.__truediv__.return_value = mock_lib
+            mock_lib.__truediv__.return_value = mock_app_support
+            mock_app_support.__truediv__.return_value = mock_anki2
+
+            mock_anki2.iterdir.return_value = [profile_dir]
+
+            assert generate_custom_stats.find_anki_collection() == db_file
+
+def test_find_anki_collection_not_found():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        profile_dir = temp_path / "Profile 1"
+        profile_dir.mkdir()
+        # No db file
+
+        with patch('pathlib.Path.home') as mock_home:
+            mock_home_path = MagicMock()
+            mock_home.return_value = mock_home_path
+
+            mock_lib = MagicMock()
+            mock_app_support = MagicMock()
+            mock_anki2 = MagicMock()
+
+            mock_home_path.__truediv__.return_value = mock_lib
+            mock_lib.__truediv__.return_value = mock_app_support
+            mock_app_support.__truediv__.return_value = mock_anki2
+
+            mock_anki2.iterdir.return_value = [profile_dir]
+
+            assert generate_custom_stats.find_anki_collection() is None

--- a/data/anki/tests/test_generate_review_stats.py
+++ b/data/anki/tests/test_generate_review_stats.py
@@ -1,0 +1,193 @@
+import pytest
+import os
+import tempfile
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import sys
+from datetime import datetime
+
+# Change directory and add to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("generate_review_stats", str(Path(__file__).parent.parent / "generate_review_stats.py"))
+generate_review_stats = importlib.util.module_from_spec(spec)
+sys.modules["generate_review_stats"] = generate_review_stats
+spec.loader.exec_module(generate_review_stats)
+
+def test_generate_review_stats_empty():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        reviews_dir = temp_path / "reviews"
+        reviews_dir.mkdir()
+
+        # Test with no files
+        with patch('generate_review_stats.REVIEWS_DIR', reviews_dir):
+            with patch('generate_review_stats.OUTPUT_FILE', temp_path / "output.json"):
+                # No reviews should return False
+                assert generate_review_stats.main() == False
+                assert not (temp_path / "output.json").exists()
+
+def test_aggregate_reviews():
+    # Write some sample data to a gzip file
+    import gzip
+
+    review_data = [
+        # Mature, good
+        {"id": 1609459200000, "cid": 1, "type": 1, "lastIvl": 21, "ivl": 30, "ease": 3, "time": 1000},
+        # Young, easy
+        {"id": 1609459200000 + 86400000, "cid": 1, "type": 1, "lastIvl": 1, "ivl": 3, "ease": 4, "time": 2000},
+        # Learn, again
+        {"id": 1609459200000 + 86400000*25, "cid": 1, "type": 0, "lastIvl": 0, "ivl": 0, "ease": 1, "time": 3000},
+        # Relearn, hard
+        {"id": 1609459200000 + 86400000*26, "cid": 1, "type": 2, "lastIvl": 30, "ivl": 10, "ease": 2, "time": 4000},
+        # Filtered, good
+        {"id": 1609459200000 + 86400000*27, "cid": 2, "type": 3, "lastIvl": 0, "ivl": 0, "ease": 3, "time": 5000},
+    ]
+
+    cards_data = [
+        {"id": 1, "deck_name": "Default\x1fSubdeck"},
+        # No cid 2 to test "Unknown"
+    ]
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+
+        reviews_dir = temp_path / "reviews"
+        reviews_dir.mkdir()
+
+        # Save reviews
+        file_path = reviews_dir / "2021-01.json.gz"
+        with gzip.open(file_path, 'wt') as f:
+            json.dump(review_data, f)
+
+        # Save cards map
+        cards_file = temp_path / "cards.json.gz"
+        with gzip.open(cards_file, 'wt') as f:
+            json.dump(cards_data, f)
+
+        with patch('generate_review_stats.REVIEWS_DIR', reviews_dir):
+            with patch('generate_review_stats.CARDS_FILE', cards_file):
+                global_stats, deck_stats = generate_review_stats.aggregate_reviews()
+
+                assert global_stats is not None
+                assert len(global_stats) == 5
+
+                assert "Default::Subdeck" in deck_stats
+                assert "Unknown" in deck_stats
+
+                assert len(deck_stats["Default::Subdeck"]) == 4
+                assert len(deck_stats["Unknown"]) == 1
+
+def test_aggregate_reviews_no_cards_file():
+    import gzip
+    review_data = [{"id": 1609459200000, "cid": 1, "type": 1, "lastIvl": 21, "ivl": 30, "ease": 3, "time": 1000}]
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        reviews_dir = temp_path / "reviews"
+        reviews_dir.mkdir()
+
+        with gzip.open(reviews_dir / "2021-01.json.gz", 'wt') as f:
+            json.dump(review_data, f)
+
+        cards_file = temp_path / "cards.json.gz" # does not exist
+
+        with patch('generate_review_stats.REVIEWS_DIR', reviews_dir):
+            with patch('generate_review_stats.CARDS_FILE', cards_file):
+                global_stats, deck_stats = generate_review_stats.aggregate_reviews()
+
+                assert "Unknown" in deck_stats
+                assert len(deck_stats["Unknown"]) == 1
+
+def test_read_existing_review_total():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        output_file = temp_path / "output.json"
+
+        # Empty missing file
+        assert generate_review_stats._read_existing_review_total(output_file) == 0
+
+        # Valid file
+        with open(output_file, "w") as f:
+            json.dump({"reviews": [{"count": 10}, {"count": 5}]}, f)
+        assert generate_review_stats._read_existing_review_total(output_file) == 15
+
+        # Invalid file
+        with open(output_file, "w") as f:
+            f.write("invalid json")
+        assert generate_review_stats._read_existing_review_total(output_file) == 0
+
+def test_should_write_reviews():
+    new_reviews = [{"count": 10}, {"count": 10}] # Total 20
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        output_file = temp_path / "output.json"
+
+        # No old file -> Write
+        assert generate_review_stats._should_write_reviews(new_reviews, output_file) == True
+
+        # Valid old file smaller -> Write
+        with open(output_file, "w") as f:
+            json.dump({"reviews": [{"count": 10}]}, f)
+        assert generate_review_stats._should_write_reviews(new_reviews, output_file) == True
+
+        # Old file large, new file empty -> Don't write
+        assert generate_review_stats._should_write_reviews([], output_file) == False
+
+        # Old file large (200), new file tiny (10) -> Don't write
+        with open(output_file, "w") as f:
+            json.dump({"reviews": [{"count": 200}]}, f)
+        assert generate_review_stats._should_write_reviews([{"count": 10}], output_file) == False
+
+def test_main_full_workflow():
+    import gzip
+    review_data = [{"id": 1609459200000, "cid": 1, "type": 1, "lastIvl": 21, "ivl": 30, "ease": 3, "time": 1000, "retention": 1}]
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        reviews_dir = temp_path / "reviews"
+        reviews_dir.mkdir()
+        output_file = temp_path / "output.json"
+
+        with gzip.open(reviews_dir / "2021-01.json.gz", 'wt') as f:
+            json.dump(review_data, f)
+
+        with patch('generate_review_stats.REVIEWS_DIR', reviews_dir), \
+             patch('generate_review_stats.OUTPUT_FILE', output_file), \
+             patch('generate_review_stats.CARDS_FILE', temp_path / "cards.json.gz"):
+
+            assert generate_review_stats.main() == True
+            assert output_file.exists()
+
+            with open(output_file) as f:
+                data = json.load(f)
+                assert len(data["reviews"]) == 1
+
+def test_main_fail_open():
+    with tempfile.TemporaryDirectory() as tempdir:
+        temp_path = Path(tempdir)
+        reviews_dir = temp_path / "reviews"
+        reviews_dir.mkdir()
+        output_file = temp_path / "output.json"
+
+        # Create valid old file
+        with open(output_file, "w") as f:
+            json.dump({"reviews": [{"count": 100}]}, f)
+
+        # Test 1: No new reviews
+        with patch('generate_review_stats.REVIEWS_DIR', reviews_dir), \
+             patch('generate_review_stats.OUTPUT_FILE', output_file):
+            assert generate_review_stats.main() == True # True because fail open
+
+        # Test 2: Suspiciously small reviews (1 review)
+        import gzip
+        with gzip.open(reviews_dir / "2021-01.json.gz", 'wt') as f:
+            json.dump([{"id": 1609459200000, "cid": 1, "type": 1, "lastIvl": 21, "ivl": 30, "ease": 3, "time": 1000}], f)
+
+        with patch('generate_review_stats.REVIEWS_DIR', reviews_dir), \
+             patch('generate_review_stats.OUTPUT_FILE', output_file), \
+             patch('generate_review_stats.CARDS_FILE', temp_path / "cards.json.gz"):
+            assert generate_review_stats.main() == True

--- a/data/anki/tests/test_migrate_hash_map.py
+++ b/data/anki/tests/test_migrate_hash_map.py
@@ -1,0 +1,165 @@
+import sys
+from pathlib import Path
+import tempfile
+import gzip
+import json
+import os
+from unittest.mock import patch, MagicMock
+
+# Add the directory to sys.path so we can import the script properly
+script_dir = Path(__file__).parent.parent
+if str(script_dir) not in sys.path:
+    sys.path.insert(0, str(script_dir))
+
+import importlib.util
+spec = importlib.util.spec_from_file_location("migrate_hash_map", str(script_dir / "migrate-hash-map.py"))
+migrate_hash_map = importlib.util.module_from_spec(spec)
+
+import pytest
+
+@pytest.fixture(autouse=True)
+def setup_module_mocks(monkeypatch):
+    """Safely setup modules for each test to avoid test pollution"""
+    import types
+    graph_mock = types.ModuleType('graph')
+    hash_map_mock = types.ModuleType('hash_map')
+    hash_map_mock.compute_note_hash = MagicMock(return_value="mock_hash")
+    hash_map_mock.load_hash_map = MagicMock(return_value={})
+    hash_map_mock.save_hash_map = MagicMock()
+
+    monkeypatch.setitem(sys.modules, 'graph', graph_mock)
+    monkeypatch.setitem(sys.modules, 'hash_map', hash_map_mock)
+
+    # Reload the module under test with the mocks in place
+    spec.loader.exec_module(migrate_hash_map)
+    monkeypatch.setitem(sys.modules, 'migrate_hash_map', migrate_hash_map)
+    yield hash_map_mock
+
+def test_compute_file_hash():
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"test content")
+        temp_path = f.name
+
+    try:
+        expected = "6ae8a75555209fd6c44157c0aed8016e763ff435a19cf186f76863140143ff72"
+        assert migrate_hash_map.compute_file_hash(temp_path) == expected
+    finally:
+        os.unlink(temp_path)
+
+def test_get_staging_dir():
+    with patch('pathlib.Path.cwd') as mock_cwd:
+        mock_cwd.return_value = Path('/mock/project')
+        with patch('pathlib.Path.exists', return_value=True):
+            assert migrate_hash_map.get_staging_dir() == Path('/mock/project/data/cloudflare')
+
+def test_get_staging_dir_fallback():
+    with patch('pathlib.Path.cwd') as mock_cwd:
+        mock_cwd.return_value = Path('/some/other/path')
+        with patch('pathlib.Path.exists', return_value=False):
+            with patch('pathlib.Path.mkdir'):
+                expected_path = Path(migrate_hash_map.__file__).parent.parent / "cloudflare"
+                assert migrate_hash_map.get_staging_dir() == expected_path
+
+def test_main_with_hash_map_exists_and_abort(setup_module_mocks):
+    with tempfile.TemporaryDirectory() as tempdir:
+        staging_dir = Path(tempdir)
+        hash_map_file = staging_dir / "hash_map.json"
+        hash_map_file.touch()
+
+        setup_module_mocks.save_hash_map.reset_mock()
+        with patch('migrate_hash_map.get_staging_dir', return_value=staging_dir):
+            with patch('builtins.input', return_value='n'):
+                migrate_hash_map.main()
+                setup_module_mocks.save_hash_map.assert_not_called()
+
+def test_main_with_corrupt_files_and_abort(setup_module_mocks):
+    with tempfile.TemporaryDirectory() as tempdir:
+        staging_dir = Path(tempdir)
+        notes_dir = staging_dir / "notes"
+        notes_dir.mkdir(parents=True)
+
+        with gzip.open(notes_dir / "corrupt.json.gz", "wt") as f:
+            f.write("not valid json")
+
+        setup_module_mocks.save_hash_map.reset_mock()
+        with patch('migrate_hash_map.get_staging_dir', return_value=staging_dir):
+            with patch('builtins.input', return_value='n'):
+                with pytest.raises(SystemExit):
+                    migrate_hash_map.main()
+                setup_module_mocks.save_hash_map.assert_not_called()
+
+def test_main_success_path(setup_module_mocks):
+    with tempfile.TemporaryDirectory() as tempdir:
+        staging_dir = Path(tempdir)
+
+        # Add collection files
+        coll_dir = staging_dir / "collection"
+        coll_dir.mkdir(parents=True)
+        with open(coll_dir / "notes.json.gz", "wb") as f:
+            f.write(b"content")
+
+        # Add a note
+        notes_dir = staging_dir / "notes"
+        notes_dir.mkdir(parents=True)
+        with gzip.open(notes_dir / "123.json.gz", "wt") as f:
+            f.write(json.dumps({"guid": "123"}))
+
+        with gzip.open(notes_dir / "456.json.gz", "wt") as f:
+            f.write(json.dumps({}))
+
+        setup_module_mocks.save_hash_map.reset_mock()
+        with patch('migrate_hash_map.get_staging_dir', return_value=staging_dir):
+            with patch('migrate_hash_map.compute_file_hash', return_value="hash_val"):
+                with patch('builtins.input', return_value='y'):
+                    migrate_hash_map.main()
+                    setup_module_mocks.save_hash_map.assert_called()
+
+def test_migrate_hash_map_continue_anyway(setup_module_mocks):
+    with tempfile.TemporaryDirectory() as tempdir:
+        staging_dir = Path(tempdir)
+        notes_dir = staging_dir / "notes"
+        notes_dir.mkdir(parents=True)
+
+        # Add a corrupt note
+        with gzip.open(notes_dir / "corrupt.json.gz", "wt") as f:
+            f.write("not valid json")
+
+        setup_module_mocks.save_hash_map.reset_mock()
+        with patch('migrate_hash_map.get_staging_dir', return_value=staging_dir):
+            with patch('builtins.input', return_value='y'):
+                migrate_hash_map.main()
+                setup_module_mocks.save_hash_map.assert_called()
+
+def test_migrate_hash_map_fallback_filename_hash(setup_module_mocks):
+    with tempfile.TemporaryDirectory() as tempdir:
+        staging_dir = Path(tempdir)
+        notes_dir = staging_dir / "notes"
+        notes_dir.mkdir(parents=True)
+
+        # Add a note without a guid
+        with gzip.open(notes_dir / "noguid.json.gz", "wt") as f:
+            json.dump({"flds": "abc"}, f)
+
+        setup_module_mocks.save_hash_map.reset_mock()
+        with patch('migrate_hash_map.get_staging_dir', return_value=staging_dir):
+            with patch('migrate_hash_map.compute_file_hash', return_value="file_hash_val"):
+                with patch('builtins.input', return_value='y'):
+                    migrate_hash_map.main()
+
+                    # Should have been saved with filename hash
+                    args, kwargs = setup_module_mocks.save_hash_map.call_args
+                    hash_map = args[0]
+                    assert "noguid.json.gz" in hash_map
+                    assert hash_map["noguid.json.gz"] == "file_hash_val"
+
+def test_missing_files_hash_map(setup_module_mocks):
+    with tempfile.TemporaryDirectory() as tempdir:
+        staging_dir = Path(tempdir)
+
+        with patch('pathlib.Path.cwd') as mock_cwd:
+            mock_cwd.return_value = staging_dir
+            with patch('migrate_hash_map.get_staging_dir', return_value=staging_dir):
+                setup_module_mocks.save_hash_map.reset_mock()
+                with patch('builtins.input', return_value='y'):
+                    migrate_hash_map.main()
+                    setup_module_mocks.save_hash_map.assert_called()


### PR DESCRIPTION
Adds comprehensive tests for `data/anki/generate_custom_stats.py`, `data/anki/generate_review_stats.py`, and `data/anki/migrate-hash-map.py` to achieve 100% code coverage for each, bringing the total repository coverage closer to 100%. Ensures mock isolation to prevent cross-test pollution in `pytest`.

---
*PR created automatically by Jules for task [4101740438989543916](https://jules.google.com/task/4101740438989543916) started by @ryusoh*