### PR TITLE
Palette: Add visible focus ring to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2024-05-18 - Add focus visible states for terminal accessibility
+
+**Learning:** When styling custom input fields, removing default browser outlines (`outline: none`) can severely hinder keyboard accessibility.
+**Action:** Always restore keyboard accessibility by adding a `:focus-visible` pseudo-class with a distinct outline (e.g., `var(--primary-color)`) so keyboard users can perceive focus without affecting mouse users.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -101,6 +101,7 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Emptying DOM elements using `element.innerHTML = ""` in `js/terminal.js` and `js/commands/handler.js` to clear output.
 **Learning:** While assigning an empty string to `innerHTML` is not actively exploitable as an XSS vector itself, retaining `.innerHTML` setters in the codebase violates strict defense-in-depth secure coding standards. It trains developers to reach for unsafe DOM manipulation APIs, keeps the codebase non-compliant with modern SAST linters (like `no-inner-html`), and risks accidental introduction of XSS if the string assignment is later modified to include untrusted variables.
 **Prevention:** Always use safe DOM APIs like `element.textContent = ""` or `element.replaceChildren()` when clearing element contents to maintain robust defense-in-depth and avoid security regressions.
+
 ## 2026-04-16 - Prevent command injection by replacing shell=True with native Python pipelines
 
 **Vulnerability:** The `subprocess.run` call inside `__exec__` in `awesome_tts/awesometts/machineid.py` used `shell=True` with string arguments containing pipes, introducing a command injection risk.

--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -12,7 +12,9 @@
 
 **Learning:** When unit testing UI or DOM-manipulating functions, explicitly assert the resulting DOM side-effects (such as `classList` modifications or `textContent` changes) and return values.
 **Prevention:** Merely executing code to hit coverage lines without asserting output or state violates testing standards.
+
 ## 2024-05-18 - handleCommand fallback and Reviews Data edge cases
+
 **Learning:** `handleCommand` correctly drops unhandled or partially matched commands by returning `{ handled: false }` rather than throwing or auto-suggesting if the prefix doesn't definitively map to a valid end state. Test coverage must ensure it falls through.
 **Action:** When testing partial commands, check for `handled: false`.
 **Learning:** `getReviewStatsData` calculates a `preSliceSum` object internally when `byDeck` is false, which accumulates historic time metrics needed for accurate rendering.

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,11 +66,16 @@
   overflow: hidden;
 }
 
-.terminal-input:focus,
-.terminal-input:focus-visible {
+.terminal-input:focus {
   outline: none !important;
   box-shadow: none !important;
   border: none !important;
+}
+
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color) !important;
+  outline-offset: 2px !important;
+  border-radius: 4px;
 }
 
 .terminal-crosshair-overlay {

--- a/js/transactions/calculations.js
+++ b/js/transactions/calculations.js
@@ -123,9 +123,15 @@ export function computeRunningTotals(transactions, splitHistory) {
   const chronologicalTransactions = new Array(len);
   for (let i = 0; i < len; i++) {
     const t = transactions[i];
-    chronologicalTransactions[i] = { t, parsedDate: new Date(t.tradeDate).getTime() };
+    chronologicalTransactions[i] = {
+      t,
+      parsedDate: new Date(t.tradeDate).getTime(),
+    };
   }
-  chronologicalTransactions.sort((a, b) => a.parsedDate - b.parsedDate || a.t.transactionId - b.t.transactionId);
+  chronologicalTransactions.sort(
+    (a, b) =>
+      a.parsedDate - b.parsedDate || a.t.transactionId - b.t.transactionId,
+  );
   for (let i = 0; i < len; i++) {
     chronologicalTransactions[i] = chronologicalTransactions[i].t;
   }


### PR DESCRIPTION
💡 What: Added a `:focus-visible` state with `outline: 2px solid var(--primary-color)` to the `#terminalInput` to explicitly support keyboard navigation.
🎯 Why: The original `outline: none !important` stripped focus visibility entirely, leaving keyboard users with no way to see where their focus was.
📸 Before/After: Focus ring now clearly visible around the terminal input when navigating using the Tab key.
♿ Accessibility: Restored standard keyboard focus indicator for users navigating via keyboard.

---
*PR created automatically by Jules for task [978939778994574762](https://jules.google.com/task/978939778994574762) started by @ryusoh*