### PR TITLE
Bolt: Replace chained reduce passes with single loop for duration stats

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,8 @@
 
 **Learning:** Re-instantiating `chronologicalTransactions` using `.map().sort().map()` chaining creates significant Garbage Collection pressure and slows down layout calculations due to intermediate array allocations on every pass. For large datasets with frequent user input, this causes main-thread blocking and UI jank.
 **Action:** Replace `O(N)` chained array passes with a single `for` loop. Pre-allocate the array and use in-place `.sort()` to bypass intermediate array instantiations and minimize overhead.
+
+## 2025-05-18 - [Optimizing chained .reduce() in array loops]
+
+**Learning:** When calculating two or more aggregated values (like total quantity and weighted sum) over the same array using separate chained `.reduce()` passes, it forces the runtime to iterate the array multiple times and allocate callbacks for each item. This increases CPU cycles and creates unnecessary garbage collection pressure on frequently computed stats.
+**Action:** Replace multiple chained `.reduce()` passes over the same array with a single standard `for` loop to compute all needed aggregates simultaneously, optimizing O(2N) down to O(N) and eliminating closure allocation overhead.

--- a/js/transactions/terminalStats.js
+++ b/js/transactions/terminalStats.js
@@ -652,15 +652,21 @@ export async function getDurationStatsText() {
       if (!lots || lots.length === 0) {
         return null;
       }
-      const totalQty = lots.reduce((sum, lot) => sum + lot.qty, 0);
+      // Bolt: Replace multiple chained .reduce() passes with a single O(N) loop
+      // to compute total quantity and weighted age simultaneously, reducing GC pressure.
+      let totalQty = 0;
+      let weightedAgeSum = 0;
+      for (let i = 0; i < lots.length; i++) {
+        const lot = lots[i];
+        totalQty += lot.qty;
+        const diffMs = Math.max(0, baselineDate - lot.date);
+        weightedAgeSum += lot.qty * (diffMs / MS_IN_DAY);
+      }
+
       if (totalQty <= 0) {
         return null;
       }
-      const avgAgeDays =
-        lots.reduce((sum, lot) => {
-          const diffMs = Math.max(0, baselineDate - lot.date);
-          return sum + lot.qty * (diffMs / MS_IN_DAY);
-        }, 0) / totalQty;
+      const avgAgeDays = weightedAgeSum / totalQty;
       return {
         ticker: formatTicker(holding.ticker),
         weight: holding.weight,


### PR DESCRIPTION
💡 What: Replaced two consecutive `.reduce()` array passes with a single `for` loop inside `getDurationStatsText` in `js/transactions/terminalStats.js`.
🎯 Why: Iterating over the `lots` array twice with `.reduce()` callbacks allocates unnecessary closures and doubles the iteration work. Consolidating the sum and weighted computations into a single loop avoids redundant iterations and reduces Garbage Collection overhead on the main thread during stats compilation.
📊 Impact: O(2N) loop iterations reduced to O(N) along with the elimination of function call overhead for the callbacks per array element.
🔬 Measurement: Can be verified using performance timeline profiles when generating duration statistics output for a highly active transaction ledger.

---
*PR created automatically by Jules for task [4134383051230625247](https://jules.google.com/task/4134383051230625247) started by @ryusoh*