### PR TITLE
Palette: Add keyboard focus outline to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,7 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2026-04-18 - Terminal Input Outline CSS
+**Learning:** Overriding global outlines using `:focus` indiscriminately applies `outline: none` for keyboard navigators if the `:focus-visible` pseudo-class is not specifically defined or uses the same override.
+**Action:** When a design requires hiding standard outlines (like on `input:focus`), explicitly separate the `.input:focus-visible` rule and apply a contrasting outline using existing theme colors (e.g., `var(--primary-color)`) so that keyboard focus indicates remain accessible without impacting standard mouse behavior.

--- a/css/terminal/terminal.css
+++ b/css/terminal/terminal.css
@@ -66,9 +66,15 @@
   overflow: hidden;
 }
 
-.terminal-input:focus,
-.terminal-input:focus-visible {
+.terminal-input:focus {
   outline: none !important;
+  box-shadow: none !important;
+  border: none !important;
+}
+
+.terminal-input:focus-visible {
+  outline: 2px solid var(--primary-color) !important;
+  outline-offset: 2px;
   box-shadow: none !important;
   border: none !important;
 }


### PR DESCRIPTION
Separated the `:focus` and `:focus-visible` states for `.terminal-input` in `terminal.css`. This ensures mouse users do not see an outline when focusing on the input, but restores a 2px solid `var(--primary-color)` outline when focused via keyboard navigation to improve accessibility. Also recorded this learning in `palette.md`.

---
*PR created automatically by Jules for task [504654334536934754](https://jules.google.com/task/504654334536934754) started by @ryusoh*