### PR TITLE
Palette: Add aria-sort to table headers for screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2025-04-19 - Screen Reader Accessibility for Sortable Table Headers
+
+**Learning:** Sortable table headers (`th` elements) lack accessibility context unless an `aria-sort` attribute is provided. Without it, screen readers cannot inform users whether the column is sortable and what its current sort order is.
+**Action:** Always provide `aria-sort="none"` on sortable table headers by default. When the sorting changes, dynamically update the `aria-sort` attribute to `ascending` or `descending` to convey the current state to screen reader users.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -107,7 +107,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** The `subprocess.run` call inside `__exec__` in `awesome_tts/awesometts/machineid.py` used `shell=True` with string arguments containing pipes, introducing a command injection risk.
 **Learning:** Shell pipelines (like `| awk` or `| cut`) can be entirely replaced by lightweight native Python string manipulations and regexes. Additionally, migrating away from `shell=True` changes the exception raised when a command is missing: instead of the shell successfully exiting with a non-zero code (triggering `subprocess.SubprocessError` when `check=True`), Python raises an `OSError` (`FileNotFoundError`).
 **Prevention:** Avoid `shell=True` in `subprocess.run` unconditionally. Pass commands as lists, replace shell pipelines with native Python parsing of the raw `subprocess.stdout`, and always catch `OSError` alongside `subprocess.SubprocessError` to preserve graceful fallbacks.
+
 ## 2024-06-11 - Prevent DOM-based XSS by removing `innerHTML` in graph data error handler
+
 **Vulnerability:** Emptying DOM elements using `loading.innerHTML = ...` in `js/graph/graph.js` to render graph fetch error messages, which injects `e.message` into the DOM.
 **Learning:** Even internal error objects should be treated as potentially unsafe input. Assigning variables to `innerHTML` without sanitization is a recurrent pattern in vanilla JS development that bypasses modern framework protections.
 **Prevention:** When dynamically rendering text content inside an element, use safe DOM methods like `document.createElement()` and `element.textContent = value` instead of template strings assigned to `innerHTML`.

--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
                 class="sortable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Date<span class="sort-indicator"></span>
               </th>
@@ -222,6 +223,7 @@
                 class="sortable filterable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Security
                 <span class="sort-indicator"></span>
@@ -236,6 +238,7 @@
                 class="sortable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Amount<span class="sort-indicator"></span>
               </th>

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -232,12 +232,19 @@ function displayTransactions(transactions) {
 function updateSortIndicators() {
   document
     .querySelectorAll("th.sortable")
-    .forEach((th) => th.removeAttribute("data-sort"));
+    .forEach((th) => {
+      th.removeAttribute("data-sort");
+      th.setAttribute("aria-sort", "none");
+    });
   const activeSorter = document.getElementById(
     `header-${transactionState.sortState.column}`,
   );
   if (activeSorter) {
     activeSorter.setAttribute("data-sort", transactionState.sortState.order);
+    activeSorter.setAttribute(
+      "aria-sort",
+      transactionState.sortState.order === "asc" ? "ascending" : "descending"
+    );
   }
 }
 


### PR DESCRIPTION
Adds the `aria-sort` attribute to sortable table headers to correctly convey their sort state (ascending, descending, or none) to screen readers.

---
*PR created automatically by Jules for task [9521589591029787039](https://jules.google.com/task/9521589591029787039) started by @ryusoh*