### PR TITLE
Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -113,3 +113,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Emptying DOM elements using `loading.innerHTML = ...` in `js/graph/graph.js` to render graph fetch error messages, which injects `e.message` into the DOM.
 **Learning:** Even internal error objects should be treated as potentially unsafe input. Assigning variables to `innerHTML` without sanitization is a recurrent pattern in vanilla JS development that bypasses modern framework protections.
 **Prevention:** When dynamically rendering text content inside an element, use safe DOM methods like `document.createElement()` and `element.textContent = value` instead of template strings assigned to `innerHTML`.
+
+## 2024-06-25 - Prevent DOM-based XSS when clearing/setting UI elements in Lab Analysis
+
+**Vulnerability:** Emptying DOM elements using `element.innerHTML = ""` or setting HTML strings like `<span style="color:var(--text-muted); padding:0 10px;">No tickers loaded</span>` directly in `js/pages/analysis/lab.js` using `innerHTML`.
+**Learning:** Assigning an empty string or seemingly safe HTML strings to `innerHTML` violates strict defense-in-depth secure coding standards and risks accidental introduction of XSS if the string assignment is later modified to include untrusted variables.
+**Prevention:** Always use safe DOM APIs like `element.textContent = ""` when clearing element contents, and use `document.createElement()` along with `.textContent` to safely construct and append UI elements dynamically.

--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -470,11 +470,14 @@ function renderSummary(config) {
   if (!summaryStatsEl) {
     return;
   }
-  summaryStatsEl.innerHTML = "";
+  summaryStatsEl.textContent = "";
 
   if (!config || !config.metrics) {
-    summaryStatsEl.innerHTML =
-      '<div style="color:var(--text-muted); padding:0 10px;">No metrics available</div>';
+    const noMetrics = document.createElement("div");
+    noMetrics.style.color = "var(--text-muted)";
+    noMetrics.style.padding = "0 10px";
+    noMetrics.textContent = "No metrics available";
+    summaryStatsEl.appendChild(noMetrics);
     return;
   }
 
@@ -508,7 +511,7 @@ function renderSummary(config) {
 
 function renderScenarioCards(config) {
   const outcomes = (config.metrics && config.metrics.outcomes) || [];
-  scenarioResultsEl.innerHTML = "";
+  scenarioResultsEl.textContent = "";
   const sharesOutstanding =
     config.metrics && Number.isFinite(config.metrics.sharesOutstanding)
       ? config.metrics.sharesOutstanding
@@ -565,7 +568,7 @@ function renderValueBands(config) {
   const exitYearValue = Number.isFinite(metrics.exitYear)
     ? metrics.exitYear
     : null;
-  valueBandsEl.innerHTML = "";
+  valueBandsEl.textContent = "";
   [
     {
       label: "Expected Terminal Price",
@@ -596,11 +599,14 @@ function renderTickerList() {
   if (!tickerListEl) {
     return;
   }
-  tickerListEl.innerHTML = "";
+  tickerListEl.textContent = "";
 
   if (!state.configs || !state.configs.length) {
-    tickerListEl.innerHTML =
-      '<span style="color:var(--text-muted); padding:0 10px;">No tickers loaded</span>';
+    const noTickers = document.createElement("span");
+    noTickers.style.color = "var(--text-muted)";
+    noTickers.style.padding = "0 10px";
+    noTickers.textContent = "No tickers loaded";
+    tickerListEl.appendChild(noTickers);
     return;
   }
 
@@ -655,7 +661,10 @@ function renderActiveTicker() {
   // Reset Risk UI
   const ctx = monteCarloCanvas.getContext("2d");
   ctx.clearRect(0, 0, monteCarloCanvas.width, monteCarloCanvas.height);
-  riskMetricsEl.innerHTML = "<p>Run simulation to see metrics.</p>";
+  riskMetricsEl.textContent = "";
+  const initialText = document.createElement("p");
+  initialText.textContent = "Run simulation to see metrics.";
+  riskMetricsEl.appendChild(initialText);
 }
 
 // --- Bayesian Handlers ---


### PR DESCRIPTION
Replaced unsafe `innerHTML` usage with secure DOM methods (`textContent` and `document.createElement()`) in `js/pages/analysis/lab.js` to mitigate DOM-based XSS risks and adhere to strict defense-in-depth secure coding standards.

---
*PR created automatically by Jules for task [4339851732815541718](https://jules.google.com/task/4339851732815541718) started by @ryusoh*