### PR TITLE
Palette: Add aria-sort to table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2026-04-20 - Sortable Table Header Accessibility
+
+**Learning:** Table headers (`th` elements) that allow sorting can be interacted with using a mouse or keyboard (if properly configured with `tabindex` and `role="button"`). However, without explicit ARIA states, screen readers do not announce the current sort order (e.g., ascending or descending) to the user, making it difficult for them to understand the table's state.
+**Action:** To ensure sortable table headers are accessible to screen readers, they must include an `aria-sort` attribute (e.g., `aria-sort="none"`). This attribute should be dynamically updated via JavaScript to `ascending` or `descending` when the sort order changes to accurately reflect the table's state.

--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
                 class="sortable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Date<span class="sort-indicator"></span>
               </th>
@@ -222,6 +223,7 @@
                 class="sortable filterable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Security
                 <span class="sort-indicator"></span>
@@ -236,6 +238,7 @@
                 class="sortable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Amount<span class="sort-indicator"></span>
               </th>

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -230,14 +230,18 @@ function displayTransactions(transactions) {
 }
 
 function updateSortIndicators() {
-  document
-    .querySelectorAll("th.sortable")
-    .forEach((th) => th.removeAttribute("data-sort"));
+  document.querySelectorAll("th.sortable").forEach((th) => {
+    th.removeAttribute("data-sort");
+    th.setAttribute("aria-sort", "none");
+  });
   const activeSorter = document.getElementById(
     `header-${transactionState.sortState.column}`,
   );
   if (activeSorter) {
     activeSorter.setAttribute("data-sort", transactionState.sortState.order);
+    const ariaOrder =
+      transactionState.sortState.order === "asc" ? "ascending" : "descending";
+    activeSorter.setAttribute("aria-sort", ariaOrder);
   }
 }
 


### PR DESCRIPTION
💡 **What**: Added the `aria-sort` attribute to sortable table headers. It defaults to "none" in the HTML and is dynamically updated by JavaScript to "ascending" or "descending" on the active header when the sort order changes.

🎯 **Why**: Without `aria-sort`, screen readers do not announce the sort state of an interactive table header to users, making it difficult for visually impaired users to understand how the data is currently organized.

♿ **Accessibility**: Significant improvement for screen reader navigation on the data table.
📸 **Before/After**: Visually unchanged, but DOM reflects correct ARIA states.

---
*PR created automatically by Jules for task [6252129126107868998](https://jules.google.com/task/6252129126107868998) started by @ryusoh*