### PR TITLE
Palette: Add aria-sort for screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2024-05-31 - Table Header Sort State Accessibility
+
+**Learning:** Sortable table headers that visually indicate their sort state (e.g., with ascending/descending arrows or custom data attributes) but lack the `aria-sort` attribute leave screen reader users unaware of the current column's sort direction, creating a confusing navigation experience.
+**Action:** When creating sortable table columns, always initialize sortable `th` elements with `aria-sort="none"` and dynamically update the attribute to `ascending` or `descending` via JavaScript whenever the sort state changes.

--- a/index.html
+++ b/index.html
@@ -203,6 +203,7 @@
                 class="sortable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Date<span class="sort-indicator"></span>
               </th>
@@ -222,6 +223,7 @@
                 class="sortable filterable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Security
                 <span class="sort-indicator"></span>
@@ -236,6 +238,7 @@
                 class="sortable"
                 tabindex="0"
                 role="button"
+                aria-sort="none"
               >
                 Amount<span class="sort-indicator"></span>
               </th>

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -232,12 +232,16 @@ function displayTransactions(transactions) {
 function updateSortIndicators() {
   document
     .querySelectorAll("th.sortable")
-    .forEach((th) => th.removeAttribute("data-sort"));
+    .forEach((th) => {
+      th.removeAttribute("data-sort");
+      th.setAttribute("aria-sort", "none");
+    });
   const activeSorter = document.getElementById(
     `header-${transactionState.sortState.column}`,
   );
   if (activeSorter) {
     activeSorter.setAttribute("data-sort", transactionState.sortState.order);
+    activeSorter.setAttribute("aria-sort", transactionState.sortState.order === "asc" ? "ascending" : "descending");
   }
 }
 


### PR DESCRIPTION
**What:**
Added the `aria-sort` attribute to interactive table headers (e.g. `th.sortable`) so that screen reader users can understand the current sorting direction of each column. It initializes as `aria-sort="none"` and updates dynamically via JavaScript.

**Why:**
Previously, table headers indicated sort state visually via data attributes (`data-sort="asc"` etc.), which screen readers might ignore. By leveraging standard `aria-sort`, we make the interactive table completely accessible.

**Accessibility:**
Significantly improved the table sorting experience for screen reader users by exposing the current state ("none", "ascending", or "descending") natively.

---
*PR created automatically by Jules for task [6719790831937611800](https://jules.google.com/task/6719790831937611800) started by @ryusoh*