### PR TITLE
Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -113,3 +113,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Emptying DOM elements using `loading.innerHTML = ...` in `js/graph/graph.js` to render graph fetch error messages, which injects `e.message` into the DOM.
 **Learning:** Even internal error objects should be treated as potentially unsafe input. Assigning variables to `innerHTML` without sanitization is a recurrent pattern in vanilla JS development that bypasses modern framework protections.
 **Prevention:** When dynamically rendering text content inside an element, use safe DOM methods like `document.createElement()` and `element.textContent = value` instead of template strings assigned to `innerHTML`.
+
+## 2026-04-21 - Prevent DOM-based XSS by removing innerHTML in lab analysis page
+
+**Vulnerability:** Emptying DOM elements or appending static HTML with `innerHTML` in `js/pages/analysis/lab.js`.
+**Learning:** While assigning static strings to `innerHTML` isn't an active XSS vector, retaining it violates strict defense-in-depth secure coding standards. It trains developers to use unsafe DOM APIs, keeps the codebase non-compliant with modern SAST linters, and risks accidental introduction of XSS.
+**Prevention:** Always use safe DOM APIs like `element.textContent = ""` or `document.createElement()` to maintain robust defense-in-depth and avoid security regressions.

--- a/js/pages/analysis/lab.js
+++ b/js/pages/analysis/lab.js
@@ -470,11 +470,14 @@ function renderSummary(config) {
   if (!summaryStatsEl) {
     return;
   }
-  summaryStatsEl.innerHTML = "";
+  summaryStatsEl.textContent = "";
 
   if (!config || !config.metrics) {
-    summaryStatsEl.innerHTML =
-      '<div style="color:var(--text-muted); padding:0 10px;">No metrics available</div>';
+    const msg = document.createElement("div");
+    msg.style.color = "var(--text-muted)";
+    msg.style.padding = "0 10px";
+    msg.textContent = "No metrics available";
+    summaryStatsEl.appendChild(msg);
     return;
   }
 
@@ -508,7 +511,7 @@ function renderSummary(config) {
 
 function renderScenarioCards(config) {
   const outcomes = (config.metrics && config.metrics.outcomes) || [];
-  scenarioResultsEl.innerHTML = "";
+  scenarioResultsEl.textContent = "";
   const sharesOutstanding =
     config.metrics && Number.isFinite(config.metrics.sharesOutstanding)
       ? config.metrics.sharesOutstanding
@@ -565,7 +568,7 @@ function renderValueBands(config) {
   const exitYearValue = Number.isFinite(metrics.exitYear)
     ? metrics.exitYear
     : null;
-  valueBandsEl.innerHTML = "";
+  valueBandsEl.textContent = "";
   [
     {
       label: "Expected Terminal Price",
@@ -596,11 +599,14 @@ function renderTickerList() {
   if (!tickerListEl) {
     return;
   }
-  tickerListEl.innerHTML = "";
+  tickerListEl.textContent = "";
 
   if (!state.configs || !state.configs.length) {
-    tickerListEl.innerHTML =
-      '<span style="color:var(--text-muted); padding:0 10px;">No tickers loaded</span>';
+    const msg = document.createElement("span");
+    msg.style.color = "var(--text-muted)";
+    msg.style.padding = "0 10px";
+    msg.textContent = "No tickers loaded";
+    tickerListEl.appendChild(msg);
     return;
   }
 
@@ -655,7 +661,10 @@ function renderActiveTicker() {
   // Reset Risk UI
   const ctx = monteCarloCanvas.getContext("2d");
   ctx.clearRect(0, 0, monteCarloCanvas.width, monteCarloCanvas.height);
-  riskMetricsEl.innerHTML = "<p>Run simulation to see metrics.</p>";
+  riskMetricsEl.textContent = "";
+  const p = document.createElement("p");
+  p.textContent = "Run simulation to see metrics.";
+  riskMetricsEl.appendChild(p);
 }
 
 // --- Bayesian Handlers ---


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]
🚨 Severity: LOW / Defense-in-Depth
💡 Vulnerability: Direct assignment to `innerHTML` when clearing and rendering elements in `js/pages/analysis/lab.js`. While the strings assigned are currently static or internal, using `innerHTML` is an unsafe anti-pattern that violates strict secure coding standards and risks accidental DOM-based XSS if user-controlled input is later introduced.
🎯 Impact: This is a proactive defense-in-depth measure. Using unsafe APIs trains developers to reach for them and prevents the codebase from passing modern SAST linters.
🔧 Fix: Replaced `innerHTML = ""` with `.textContent = ""` and replaced template strings concatenated to `innerHTML` with `document.createElement()` and `.textContent` assignments.
✅ Verification: Ran `make check-node` and fully verified the UI functionality using a local server and Playwright script (`frontend_verification_complete`).

---
*PR created automatically by Jules for task [1903177072315302950](https://jules.google.com/task/1903177072315302950) started by @ryusoh*