### PR TITLE
Palette: Add aria-sort to interactive table headers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,9 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+
+## 2026-04-22 - aria-sort Constraint Conflict
+
+**Learning:** When adding `aria-sort` to table headers (`th`) to indicate sort states for screen readers, it directly conflicts with explicitly setting `role="button"`. The `aria-sort` attribute is only valid on `columnheader` or `rowheader` roles (which `th` has by default). If a `th` is given `role="button"` to satisfy a different rule, adding `aria-sort` creates invalid ARIA, rendering the sort state feedback completely broken for screen readers.
+**Action:** When implementing sortable table headers, prioritize the native `columnheader` role of `th` and apply `aria-sort` to it. If interactive button behavior is strictly required, either wrap the content in a real `<button>` element inside the `th`, or remove the overriding `role="button"` on the `th` while ensuring keyboard event listeners still exist. Never combine `role="button"` and `aria-sort` on the same `th` element.

--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@
                 id="header-tradeDate"
                 class="sortable"
                 tabindex="0"
-                role="button"
+                aria-sort="none"
               >
                 Date<span class="sort-indicator"></span>
               </th>
@@ -210,7 +210,6 @@
                 id="header-orderType"
                 class="filterable"
                 tabindex="0"
-                role="button"
               >
                 Type
                 <span class="filter-indicator" aria-hidden="true">
@@ -221,7 +220,7 @@
                 id="header-security"
                 class="sortable filterable"
                 tabindex="0"
-                role="button"
+                aria-sort="none"
               >
                 Security
                 <span class="sort-indicator"></span>
@@ -235,7 +234,7 @@
                 id="header-netAmount"
                 class="sortable"
                 tabindex="0"
-                role="button"
+                aria-sort="none"
               >
                 Amount<span class="sort-indicator"></span>
               </th>

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -230,14 +230,19 @@ function displayTransactions(transactions) {
 }
 
 function updateSortIndicators() {
-  document
-    .querySelectorAll("th.sortable")
-    .forEach((th) => th.removeAttribute("data-sort"));
+  document.querySelectorAll("th.sortable").forEach((th) => {
+    th.removeAttribute("data-sort");
+    th.setAttribute("aria-sort", "none");
+  });
   const activeSorter = document.getElementById(
     `header-${transactionState.sortState.column}`,
   );
   if (activeSorter) {
     activeSorter.setAttribute("data-sort", transactionState.sortState.order);
+    activeSorter.setAttribute(
+      "aria-sort",
+      transactionState.sortState.order === "asc" ? "ascending" : "descending",
+    );
   }
 }
 


### PR DESCRIPTION
Resolves an accessibility issue where interactive sortable table headers lacked the proper ARIA attributes to indicate their sort state to screen readers.

- Added `aria-sort="none"` to sortable table headers (`<th>`) in `index.html`.
- Removed `role="button"` from headers to resolve ARIA conflicts, as `aria-sort` requires `columnheader` (implicit to `<th>`).
- Updated `js/transactions/table.js` to dynamically apply `ascending` or `descending` based on the active sort state.
- Recorded a learning in `.jules/palette.md` regarding the ARIA conflict.

---
*PR created automatically by Jules for task [13598096894213067237](https://jules.google.com/task/13598096894213067237) started by @ryusoh*