### PR TITLE
Palette: Improve table header accessibility with aria-sort

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,8 @@
 
 **Learning:** Terminal emulators or command-line interfaces built with web technologies that dynamically append command output and results using JavaScript are entirely invisible to assistive technologies like screen readers if no ARIA live regions are used. Without explicit indication, screen reader users input a command, hit enter, and receive absolutely no feedback.
 **Action:** When building custom web-based terminal interfaces or logs, always ensure the container holding the output stream uses `role="log"` and `aria-live="polite"` so new lines are announced without interrupting the user. Additionally, route dedicated command error messages to a container with `aria-live="assertive" role="alert"` to immediately interrupt and alert the user of failure.
+
+## 2026-04-23 - Table Header Accessibility via Aria-Sort
+
+**Learning:** To ensure sortable table headers (`th` elements) are correctly announced by screen readers, they must retain their implicit `columnheader` role. Setting `role="button"` overrides this and invalidates the `aria-sort` state. `aria-sort` should be added dynamically (`none`, `ascending`, `descending`) to the native `th` element.
+**Action:** Always preserve the implicit role of `th` elements when building sortable tables. Add `aria-sort` attributes instead of custom `role="button"` and ensure JavaScript updates it dynamically.

--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
                 id="header-tradeDate"
                 class="sortable"
                 tabindex="0"
-                role="button"
+                aria-sort="none"
               >
                 Date<span class="sort-indicator"></span>
               </th>
@@ -228,7 +228,6 @@
                 id="header-orderType"
                 class="filterable"
                 tabindex="0"
-                role="button"
               >
                 Type
                 <span class="filter-indicator" aria-hidden="true">
@@ -239,7 +238,7 @@
                 id="header-security"
                 class="sortable filterable"
                 tabindex="0"
-                role="button"
+                aria-sort="none"
               >
                 Security
                 <span class="sort-indicator"></span>
@@ -253,7 +252,7 @@
                 id="header-netAmount"
                 class="sortable"
                 tabindex="0"
-                role="button"
+                aria-sort="none"
               >
                 Amount<span class="sort-indicator"></span>
               </th>

--- a/js/transactions/table.js
+++ b/js/transactions/table.js
@@ -232,12 +232,19 @@ function displayTransactions(transactions) {
 function updateSortIndicators() {
   document
     .querySelectorAll("th.sortable")
-    .forEach((th) => th.removeAttribute("data-sort"));
+    .forEach((th) => {
+      th.removeAttribute("data-sort");
+      th.setAttribute("aria-sort", "none");
+    });
   const activeSorter = document.getElementById(
     `header-${transactionState.sortState.column}`,
   );
   if (activeSorter) {
     activeSorter.setAttribute("data-sort", transactionState.sortState.order);
+    activeSorter.setAttribute(
+      "aria-sort",
+      transactionState.sortState.order === "asc" ? "ascending" : "descending",
+    );
   }
 }
 


### PR DESCRIPTION
Removed the invalid `role="button"` assignment on `<th>` elements and explicitly declared `aria-sort="none"` in `index.html`. Updated sort interaction logic in `js/transactions/table.js` to accurately toggle `aria-sort` between `ascending` and `descending`.

This change properly informs screen readers about the sortable states of the columns without compromising the element's implicitly expected `columnheader` role.

---
*PR created automatically by Jules for task [1730722013940939361](https://jules.google.com/task/1730722013940939361) started by @ryusoh*