### PR TITLE
Sentinel: [MEDIUM] Fix missing timeout on Azure API requests

### DIFF
--- a/awesome_tts/awesometts/service/azure.py
+++ b/awesome_tts/awesometts/service/azure.py
@@ -167,7 +167,7 @@ class Azure(Service):
         headers = {
             'Ocp-Apim-Subscription-Key': subscription_key
         }
-        response = requests.post(fetch_token_url, headers=headers)
+        response = requests.post(fetch_token_url, headers=headers, timeout=10)
         self.access_token = str(response.text)
         self.access_token_timestamp = datetime.datetime.now()
         self._logger.debug(f'requested access_token')
@@ -231,7 +231,7 @@ class Azure(Service):
             
             body = ssml_str.encode(encoding='utf-8')
 
-            response = requests.post(constructed_url, headers=headers, data=body)
+            response = requests.post(constructed_url, headers=headers, data=body, timeout=10)
             if response.status_code == 200:
                 with open(path, 'wb') as audio:
                     audio.write(response.content)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing timeout on external API requests (`requests.post` in `azure.py`).
🎯 Impact: The application thread could hang indefinitely if the external Azure API server fails to respond, potentially leading to resource exhaustion or a Denial of Service (DoS) state.
🔧 Fix: Added `timeout=10` to both `requests.post` calls in `awesome_tts/awesometts/service/azure.py` (token fetching and speech synthesis).
✅ Verification: Code reviewed to ensure `timeout=10` is present. Tests (`make check-py`) and linters (`make lint`) run and passing.

---
*PR created automatically by Jules for task [2961658270974926574](https://jules.google.com/task/2961658270974926574) started by @ryusoh*