### PR TITLE
Bolt: [performance improvement] Optimize maxDay calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -102,3 +102,8 @@
 
 **Learning:** When defining `callbacks: { title: (items) => items.map(item => item.label).join('\n') }` within interactive libraries like Chart.js tooltips, chained array mapping and joining during high-frequency mouse hover operations cause numerous intermediate Array allocations and heavy Garbage Collection spikes in hot paths.
 **Action:** Replace `.map().join()` with standard `.length` iteration inside interactive callback functions. Iteratively construct primitive strings with standard string concatenation and a single native `for` loop to eliminate intermittent Array heap allocations completely.
+
+## 2025-05-19 - [Optimize flatMap Array loops]
+
+**Learning:** When calculating max values using `Object.values(data).flatMap(entries => entries.map(e => e.day))`, multiple chained iterations create extensive array instantiation allocations on the heap, and put heavy load on GC due to discarding intermediate array states during layout rendering.
+**Action:** Use native primitive standard iteration to bypass `.flatMap()` entirely, creating 0 new intermediate array allocations.

--- a/js/commands/due.js
+++ b/js/commands/due.js
@@ -103,11 +103,14 @@ export function renderFutureDueChart(data, byDeck = false, rangeDays = null) {
   let maxDay = 0;
   /* c8 ignore next 10 */
   if (byDeck) {
-    const allDays = Object.values(data).flatMap((entries) =>
-      entries.map((e) => e.day),
-    );
-    if (allDays.length > 0) {
-      maxDay = Math.max(...allDays);
+    // Bolt: Use native for loops to find the max day instead of .flatMap().map()
+    // This avoids large intermediate array allocations and prevents Math.max stack overflow on large datasets.
+    for (const entries of Object.values(data)) {
+      for (let i = 0, len = entries.length; i < len; i++) {
+        if (entries[i].day > maxDay) {
+          maxDay = entries[i].day;
+        }
+      }
     }
   } else {
     maxDay = data.length > 0 ? data[data.length - 1].day : 0;


### PR DESCRIPTION
💡 What: Replaced `.flatMap().map()` chain with native `for` loops in `js/commands/due.js`. Added explanatory comments to the code.
🎯 Why: `.flatMap().map()` creates large intermediate arrays on the heap which increases garbage collection pressure, and using the spread operator on a large array in `Math.max(...allDays)` can cause a `RangeError: Maximum call stack size exceeded`.
📊 Impact: Eliminates O(N) intermediate array allocations and prevents potential V8 stack overflow errors for large user decks, ensuring smoother layout rendering.
🔬 Measurement: Run the test suite using `make check-node` and verify frontend behaviour with `make lint`.

---
*PR created automatically by Jules for task [1918480881036832084](https://jules.google.com/task/1918480881036832084) started by @ryusoh*