### PR TITLE
Palette: Add accessible label to graph timeline slider

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -45,3 +45,8 @@
 
 **Learning:** When custom styling navigation links or buttons requires removing default browser outlines (`outline: none`), it breaks keyboard navigation accessibility because users can no longer perceive which element has focus.
 **Action:** Always restore keyboard accessibility by adding a `:focus-visible` pseudo-class with a distinct outline (e.g., `outline: 2px solid rgba(255, 255, 255, 0.5)`) so keyboard users can perceive focus without affecting mouse users.
+
+## 2024-05-31 - Range Input Slider Accessibility
+
+**Learning:** When building custom interactive components like timelines with `<input type="range">`, the native input often lacks context for screen reader users because its surrounding visual context (like floating date tooltips or min/max bounds) isn't semantically linked.
+**Action:** Always provide an explicit `aria-label` (e.g., "Timeline progress slider") or use `aria-labelledby` for range inputs to ensure screen reader users understand the specific purpose of the control.

--- a/graph/index.html
+++ b/graph/index.html
@@ -95,6 +95,7 @@
             min="0"
             max="100"
             value="0"
+            aria-label="Timeline progress slider"
           />
           <div id="magnetic-thumb"></div>
         </div>


### PR DESCRIPTION
💡 What: Added an `aria-label="Timeline progress slider"` to the `<input type="range">` in the graph UI.
🎯 Why: The native slider input lacked semantic context, meaning screen reader users would not know what the slider controls or its purpose.
♿ Accessibility: Improves accessibility for screen reader users by providing a descriptive accessible name for the control.

---
*PR created automatically by Jules for task [11898571765739257921](https://jules.google.com/task/11898571765739257921) started by @ryusoh*