### PR TITLE
Sentinel: [HIGH] Fix missing timeouts in requests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -130,3 +130,8 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Emptying DOM elements using `loading.innerHTML = ...` in `js/graph/graph.js` to render graph fetch error messages, which injects `e.message` into the DOM.
 **Learning:** Even internal error objects should be treated as potentially unsafe input. Assigning variables to `innerHTML` without sanitization is a recurrent pattern in vanilla JS development that bypasses modern framework protections.
 **Prevention:** When dynamically rendering text content inside an element, use safe DOM methods like `document.createElement()` and `element.textContent = value` instead of template strings assigned to `innerHTML`.
+
+## 2024-05-01 - [Missing Timeout Parameter in requests]
+**Vulnerability:** Several API integrations using Python's `requests` library lacked a `timeout` parameter.
+**Learning:** External network calls without explicit timeouts can cause the application thread to hang indefinitely, resulting in DoS vulnerabilities or unresponsive applications when the external service is slow or unresponsive.
+**Prevention:** Always include a `timeout` parameter (e.g., `timeout=10`) wrapped within a `try...except requests.exceptions.RequestException` block when using the `requests` library to interact with external services.

--- a/awesome_tts/awesometts/service/cereproc.py
+++ b/awesome_tts/awesometts/service/cereproc.py
@@ -74,7 +74,10 @@ class CereProc(Service):
         headers = {'authorization': f'Basic {auth_string}'}
 
         auth_url = 'https://api.cerevoice.com/v2/auth'
-        response = requests.get(auth_url, headers=headers)
+        try:
+            response = requests.get(auth_url, headers=headers, timeout=10)
+        except requests.exceptions.RequestException as e:
+            raise ValueError(f"Network error: {e}")
 
         access_token = response.json()['access_token']
         return access_token
@@ -109,7 +112,11 @@ class CereProc(Service):
 
             url = f'https://api.cerevoice.com/v2/speak?voice={voice_name}&audio_format=mp3'
             # logging.debug(f'querying url: {url}')            
-            response = requests.post(url, data=ssml_text, headers=self.get_auth_headers(username, password))
+            try:
+                response = requests.post(url, data=ssml_text, headers=self.get_auth_headers(username, password), timeout=10)
+            except requests.exceptions.RequestException as e:
+                self._logger.error(f"Network error: {e}")
+                raise ValueError(f"Network error: {e}")
 
             if response.status_code == 200:
                 with open(path, 'wb') as audio:

--- a/awesome_tts/awesometts/service/forvo.py
+++ b/awesome_tts/awesometts/service/forvo.py
@@ -823,7 +823,7 @@ class Forvo(Service):
             # run request
             headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:85.0) Gecko/20100101 Firefox/85.0'}
             try:
-                response = requests.get(url, headers=headers)
+                response = requests.get(url, headers=headers, timeout=10)
                 self._logger.debug(f'response.content: {response.content}')
             except requests.exceptions.SSLError as e:
                 message = f"SSL Certificate verification failed when contacting Forvo API. This is usually due to Forvo's servers having an invalid or expired certificate. Details: {e}"
@@ -852,7 +852,7 @@ class Forvo(Service):
                         break
 
                 try:
-                    response = requests.get(audio_url)
+                    response = requests.get(audio_url, timeout=10)
                     response.raise_for_status()
                 except requests.exceptions.SSLError as e:
                     message = f"SSL Certificate verification failed when downloading audio from Forvo. Details: {e}"

--- a/awesome_tts/awesometts/service/fptai.py
+++ b/awesome_tts/awesometts/service/fptai.py
@@ -125,7 +125,11 @@ class FptAi(Service):
 
             api_url = "https://api.fpt.ai/hmi/tts/v5"
             body = text
-            response = requests.post(api_url, headers=headers, data=body.encode('utf-8'))
+            try:
+                response = requests.post(api_url, headers=headers, data=body.encode('utf-8'), timeout=10)
+            except requests.exceptions.RequestException as e:
+                self._logger.error(f"Network error: {e}")
+                raise ValueError(f"Network error: {e}")
 
             self._logger.debug(f'executing POST on {api_url} with headers {headers}, text: {text}')
 
@@ -152,7 +156,12 @@ class FptAi(Service):
             wait_time = 0.2
             while audio_available == False and max_tries > 0:
                 time.sleep(wait_time)
-                r = requests.get(async_url, allow_redirects=True)
+                try:
+                    r = requests.get(async_url, allow_redirects=True, timeout=10)
+                except requests.exceptions.RequestException as e:
+                    self._logger.error(f"Network error: {e}")
+                    audio_available = False
+                    break
                 self._logger.debug(f"status code: {r.status_code}")
                 if r.status_code == 200:
                     audio_available = True

--- a/awesome_tts/awesometts/service/naver.py
+++ b/awesome_tts/awesometts/service/naver.py
@@ -232,7 +232,10 @@ class Naver(Service):
         )        
         headers = _generate_headers()
         self._logger.info(f'executing POST request on {url} with headers={headers}, data={params}')
-        response = requests.post(url, headers=headers, data=params)
+        try:
+            response = requests.post(url, headers=headers, data=params, timeout=10)
+        except requests.exceptions.RequestException as e:
+            raise Exception(f"Network error: {e}")
         if response.status_code != 200:
             raise Exception(f'got status_code {response.status_code} from {url}: {response.content} ')
 

--- a/awesome_tts/awesometts/service/vocalware.py
+++ b/awesome_tts/awesometts/service/vocalware.py
@@ -101,7 +101,10 @@ class VocalWare(Service):
             url_parameters = f"""EID={voice_key['engine_id']}&LID={voice_key['language_id']}&VID={voice_key['voice_id']}&TXT={urlencoded_text}&ACC={account_id}&API={api_id}&CS={checksum}"""
             url = f"""http://www.vocalware.com/tts/gen.php?{url_parameters}"""
 
-            response = requests.get(url)
+            try:
+                response = requests.get(url, timeout=10)
+            except requests.exceptions.RequestException as e:
+                raise ValueError(f"Network error: {e}")
             if response.status_code == 200:
                 with open(path, 'wb') as audio:
                     audio.write(response.content)

--- a/awesome_tts/awesometts/service/watson.py
+++ b/awesome_tts/awesometts/service/watson.py
@@ -111,7 +111,11 @@ class Watson(Service):
             }
 
             self._logger.info(f'data: {data}')
-            response = requests.post(constructed_url, data=json.dumps(data), auth=('apikey', api_key), headers=headers)
+            try:
+                response = requests.post(constructed_url, data=json.dumps(data), auth=('apikey', api_key), headers=headers, timeout=10)
+            except requests.exceptions.RequestException as e:
+                self._logger.error(f"Network error: {e}")
+                raise ValueError(f"Network error: {e}")
 
             if response.status_code == 200:
                 with open(path, 'wb') as audio:


### PR DESCRIPTION
Adds missing timeout=10 to multiple requests.get and requests.post calls to prevent thread hanging on unresponsive APIs.

---
*PR created automatically by Jules for task [16458038096930258295](https://jules.google.com/task/16458038096930258295) started by @ryusoh*