### PR TITLE
Bolt: Optimize future due by-deck filtering with early exit

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -117,3 +117,8 @@
 
 **Learning:** In `js/commands/reviews.js`, deriving target dates (`targetDates = globalSlice.map((d) => d.date)`) and padding missing entries (`paddedEntries = targetDates.map((date) => { ... })`) created multiple unneeded array allocations on every invocation, putting unnecessary pressure on garbage collection.
 **Action:** Replace functional array `.map()` derivations in frequently-executed code with standard `for` loops using pre-allocated arrays (`new Array(length)`) to minimize object instantiation overhead and reduce garbage collection impact.
+
+## 2025-05-19 - [Optimize .filter() on Pre-Sorted Arrays]
+
+**Learning:** When filtering data arrays that are already guaranteed to be sorted by the backend (like chronological days in `futureDue`), using `Array.prototype.filter()` iterates over the entire O(N) collection, creating severe Garbage Collection pressure from closure allocation and wasting execution time on guaranteed-invalid subsequent elements.
+**Action:** Replace `Array.prototype.filter()` with a native `for` loop combined with an early `break` statement when the condition is guaranteed to no longer match, reducing operations from O(N) to O(K) where K is the number of valid matches.

--- a/js/commands/due.js
+++ b/js/commands/due.js
@@ -39,9 +39,15 @@ export function getFutureDueData(rangeKey = DEFAULT_RANGE, byDeck = false) {
     const limitedData = {};
     for (const [deckName, entries] of Object.entries(allData)) {
       if (Array.isArray(entries)) {
-        // Find indices within the day range
+        // Bolt: Optimize sorted array filtering with early exit to avoid O(N) traversal.
         // Since entries are sorted by day in the Python export, we can stop at `day >= days`
-        limitedData[deckName] = entries.filter((e) => e.day < days);
+        const filtered = [];
+        for (let i = 0, len = entries.length; i < len; i++) {
+          const e = entries[i];
+          if (e.day >= days) break;
+          filtered.push(e);
+        }
+        limitedData[deckName] = filtered;
       }
     }
     return limitedData;


### PR DESCRIPTION
Bolt: Optimize future due by-deck filtering with early exit

💡 What: Replaced an `Array.prototype.filter()` call with a native `for` loop and an early `break` in the `getFutureDueData` function.
🎯 Why: The target array (`entries`) is already chronologically sorted by the Python backend. `.filter()` unnecessarily iterates the entire array in O(N) time and creates Garbage Collection overhead from closures. A native loop with an early break operates in O(K) time, stopping exactly when necessary, and avoids callback allocations.
📊 Impact: Eliminates O(N) traversal on potentially thousands of future due entries per deck, optimizing to O(K) where K is the number of valid days. This significantly reduces execution time and Garbage Collection pressure during dashboard initialization for users with large Anki profiles.
🔬 Measurement: Run `make check-node` to ensure all tests pass (verifying the logic returns the exact same array subsets). The performance win can be measured via the browser DevTools Performance tab during initial dashboard load on an Anki profile with years of future scheduled reviews.

---
*PR created automatically by Jules for task [2035081563382034328](https://jules.google.com/task/2035081563382034328) started by @ryusoh*