### PR TITLE
Bolt: Optimize array allocations in due.js

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -132,3 +132,8 @@
 
 **Learning:** In `js/ui/nav_prefetch.js`, chaining `.filter().forEach()` over `Object.keys()` combined with an inner `.forEach()` created unnecessary intermediate array allocations, increasing garbage collection pressure during the background prefetch initialization.
 **Action:** Replace `Array.prototype.filter().forEach()` chains over Object properties with standard native `for` loops, adding early `continue` statements to emulate the filter, to eliminate intermediate array closures and minimize GC overhead.
+
+## 2025-05-19 - [Optimize Array.from with dummy objects]
+
+**Learning:** Using `Array.from({ length: N }, callback)` for mapping creates an intermediate array-like object with a `length` property which causes callback overhead and object allocation garbage collection pressure inside chart rendering loops.
+**Action:** Replace `Array.from()` map initializations in hot paths with pre-allocated native arrays (`new Array(N)`) combined with standard native `for` loops to directly assign values. This completely eliminates dummy array-like object instantiations and callback function GC overhead.

--- a/js/commands/due.js
+++ b/js/commands/due.js
@@ -127,11 +127,12 @@ export function renderFutureDueChart(data, byDeck = false, rangeDays = null) {
   }
 
   const numDays = maxDay + 1;
-  const labels = Array.from({ length: numDays }, (_, i) => {
-    if (i === 0) return "Today";
-    if (i === 1) return "Tomorrow";
-    return `+${i}d`;
-  });
+  const labels = new Array(numDays);
+  for (let i = 0; i < numDays; i++) {
+    if (i === 0) labels[i] = "Today";
+    else if (i === 1) labels[i] = "Tomorrow";
+    else labels[i] = `+${i}d`;
+  }
 
   const datasets = [];
 
@@ -158,10 +159,10 @@ export function renderFutureDueChart(data, byDeck = false, rangeDays = null) {
           daySparseMap[e.day] = (e.mature || 0) + (e.young || 0);
         }
 
-        const counts = Array.from(
-          { length: numDays },
-          (_, i) => daySparseMap[i] || 0,
-        );
+        const counts = new Array(numDays);
+        for (let i = 0; i < numDays; i++) {
+          counts[i] = daySparseMap[i] || 0;
+        }
 
         const color = getGroupedDeckColor(
           deckInfo.groupIndex,
@@ -208,14 +209,12 @@ export function renderFutureDueChart(data, byDeck = false, rangeDays = null) {
       dayMapYoung[e.day] = e.young || 0;
     }
 
-    const matureDataset = Array.from(
-      { length: numDays },
-      (_, i) => dayMapMature[i] || 0,
-    );
-    const youngDataset = Array.from(
-      { length: numDays },
-      (_, i) => dayMapYoung[i] || 0,
-    );
+    const matureDataset = new Array(numDays);
+    const youngDataset = new Array(numDays);
+    for (let i = 0; i < numDays; i++) {
+      matureDataset[i] = dayMapMature[i] || 0;
+      youngDataset[i] = dayMapYoung[i] || 0;
+    }
 
     /* c8 ignore next */
     const radius = numDays > 100 ? 0 : 4;


### PR DESCRIPTION
💡 What: Replaced `Array.from` mappings with native `for` loops and pre-allocated arrays.
🎯 Why: Using `Array.from` with dummy `{ length: N }` objects causes heavy GC pressure and callback overhead in chart rendering hot-paths. 
📊 Impact: Eliminates unneeded dummy objects and intermediate callback allocations, making chart rendering (especially for many decks) smoother and lighter on memory.
🔬 Measurement: Verified with `make check-node`. Run the `due deck` command in the terminal to observe rendering speed and memory usage vs baseline.

---
*PR created automatically by Jules for task [258241525687963159](https://jules.google.com/task/258241525687963159) started by @ryusoh*