### PR TITLE
Bolt: Optimize Set iteration in timeline slider to reduce GC pressure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -137,3 +137,8 @@
 
 **Learning:** Using `Array.from({ length: N }, callback)` for mapping creates an intermediate array-like object with a `length` property which causes callback overhead and object allocation garbage collection pressure inside chart rendering loops.
 **Action:** Replace `Array.from()` map initializations in hot paths with pre-allocated native arrays (`new Array(N)`) combined with standard native `for` loops to directly assign values. This completely eliminates dummy array-like object instantiations and callback function GC overhead.
+
+## 2025-05-19 - [Optimize Set Iterations in Hot Paths]
+
+**Learning:** When executing rapid UI callbacks (such as scrubbing a timeline slider), iterating over Sets using `Set.prototype.forEach((item) => { ... })` incurs significant garbage collection (GC) overhead due to the constant allocation of anonymous callback functions on every execution.
+**Action:** Replace `Set.prototype.forEach()` in high-frequency or animation hot paths with native `for...of` loops (e.g., `for (const item of mySet) { ... }`) to eliminate closure allocations and minimize GC spikes.

--- a/js/graph/graph.js
+++ b/js/graph/graph.js
@@ -465,7 +465,7 @@ function updateTimeline() {
   }
   const degree1 = new Set();
 
-  activeSet.forEach((id) => {
+  for (const id of activeSet) {
     const neighbors = adjacency.get(id);
     if (neighbors) {
       for (let j = 0; j < neighbors.length; j++) {
@@ -473,7 +473,7 @@ function updateTimeline() {
         if (!activeSet.has(targetId)) degree1.add(targetId);
       }
     }
-  });
+  }
 
   const dateTop =
     document.getElementById("date-top") ||
@@ -489,11 +489,11 @@ function updateTimeline() {
   // Update Highlight Nodes (Now O(1) Lookups)
   let hiIdx = 0;
 
-  activeSet.forEach((id) => {
-    if (hiIdx >= MAX_HI) return;
+  for (const id of activeSet) {
+    if (hiIdx >= MAX_HI) break;
     const p = nodeMap.get(id);
     const c = nodeColorMap.get(id) || fallbackColor;
-    if (!p) return;
+    if (!p) continue;
 
     hiPos[hiIdx * 3] = p.x;
     hiPos[hiIdx * 3 + 1] = p.y;
@@ -504,13 +504,13 @@ function updateTimeline() {
     hiSiz[hiIdx] = p.size * 65; // Proportional to PageRank
     hiAlp[hiIdx] = 1.0;
     hiIdx++;
-  });
+  }
 
-  degree1.forEach((id) => {
-    if (hiIdx >= MAX_HI) return;
+  for (const id of degree1) {
+    if (hiIdx >= MAX_HI) break;
     const p = nodeMap.get(id);
     const c = nodeColorMap.get(id) || fallbackColor;
-    if (!p) return;
+    if (!p) continue;
 
     hiPos[hiIdx * 3] = p.x;
     hiPos[hiIdx * 3 + 1] = p.y;
@@ -521,7 +521,7 @@ function updateTimeline() {
     hiSiz[hiIdx] = p.size * 25; // Sub-highlights also proportional
     hiAlp[hiIdx] = 0.4;
     hiIdx++;
-  });
+  }
 
   // Zero out rest to hide them
   for (let i = hiIdx; i < MAX_HI; i++) {
@@ -537,12 +537,15 @@ function updateTimeline() {
 
   // Update Highlight Edges
   let hiEIdx = 0;
-  activeSet.forEach((sId) => {
-    (adjacency.get(sId) || []).forEach((l) => {
-      if (hiEIdx >= MAX_HI) return;
+  for (const sId of activeSet) {
+    if (hiEIdx >= MAX_HI) break;
+    const edges = adjacency.get(sId) || [];
+    for (let i = 0; i < edges.length; i++) {
+      if (hiEIdx >= MAX_HI) break;
+      const l = edges[i];
       const s = nodeMap.get(sId),
         t = nodeMap.get(l.target);
-      if (!s || !t) return;
+      if (!s || !t) continue;
       const o = hiEIdx * 6;
       hiEdgePos[o] = s.x;
       hiEdgePos[o + 1] = s.y;
@@ -577,8 +580,8 @@ function updateTimeline() {
       hiEdgeAlp[hiEIdx * 2] = a;
       hiEdgeAlp[hiEIdx * 2 + 1] = a;
       hiEIdx++;
-    });
-  });
+    }
+  }
   hiEdgeGeom.setDrawRange(0, hiEIdx * 2);
   hiEdgeGeom.attributes.position.needsUpdate = true;
   hiEdgeGeom.attributes.aColor.needsUpdate = true;


### PR DESCRIPTION
💡 What: Replaced `Set.prototype.forEach()` loops with native `for...of` loops in the timeline slider update logic.
🎯 Why: The `updateTimeline` function runs continuously when scrubbing the timeline. Using `forEach` creates an anonymous function closure on every loop iteration, leading to significant garbage collection overhead and potential jank during rapid execution.
📊 Impact: Eliminates closure allocations during timeline scrubbing, reducing GC spikes and main-thread blocking. Converts O(N) early-return simulated loops into true early-exit `break` loops.
🔬 Measurement: Verify by scrubbing the timeline in the graph view and observing smoother frame rates and fewer GC pauses in the DevTools Performance tab.

---
*PR created automatically by Jules for task [14266210116796717430](https://jules.google.com/task/14266210116796717430) started by @ryusoh*