### PR TITLE
Palette: Fix table header ARIA sort state accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -50,3 +50,8 @@
 
 **Learning:** When building custom interactive components like timelines with `<input type="range">`, the native input often lacks context for screen reader users because its surrounding visual context (like floating date tooltips or min/max bounds) isn't semantically linked.
 **Action:** Always provide an explicit `aria-label` (e.g., "Timeline progress slider") or use `aria-labelledby` for range inputs to ensure screen reader users understand the specific purpose of the control.
+
+## 2024-06-05 - ARIA Sort States on Table Headers
+
+**Learning:** When making table headers (`th` elements) sortable, overriding their inherent `columnheader` role by adding `role="button"` breaks their ability to convey sorting state to screen readers. `aria-sort` is only a valid attribute on elements with `columnheader` or `rowheader` roles.
+**Action:** Do not use `role="button"` on interactive `th` elements. Instead, apply `tabindex="0"` for keyboard accessibility and initialize them with `aria-sort="none"` (or `ascending`/`descending` as appropriate) to correctly expose the sortable semantics and state.

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -235,7 +235,7 @@
                   id="header-tradeDate"
                   class="sortable"
                   tabindex="0"
-                  role="button"
+                  aria-sort="none"
                 >
                   Date<span class="sort-indicator"></span>
                 </th>
@@ -243,7 +243,6 @@
                   id="header-orderType"
                   class="filterable"
                   tabindex="0"
-                  role="button"
                 >
                   Type
                   <span class="filter-indicator" aria-hidden="true">
@@ -254,7 +253,7 @@
                   id="header-security"
                   class="sortable filterable"
                   tabindex="0"
-                  role="button"
+                  aria-sort="none"
                 >
                   Security
                   <span class="sort-indicator"></span>
@@ -268,7 +267,7 @@
                   id="header-netAmount"
                   class="sortable"
                   tabindex="0"
-                  role="button"
+                  aria-sort="none"
                 >
                   Amount<span class="sort-indicator"></span>
                 </th>


### PR DESCRIPTION
Removed `role="button"` from table headers (`th` elements) that represent sortable columns. Overriding the implicit `columnheader` role with `button` invalidates the `aria-sort` state for screen readers. Instead, added `aria-sort="none"` to initially indicate the sortable state natively while retaining keyboard accessibility via `tabindex="0"`. Logged learning to palette journal.

---
*PR created automatically by Jules for task [6989262313430043203](https://jules.google.com/task/6989262313430043203) started by @ryusoh*