### PR TITLE
Bolt: Fix layout thrashing in table glass effect render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -147,3 +147,8 @@
 
 **Learning:** Re-instantiating small objects (like `{ x, y }` points) inside high-frequency execution loops, such as HTML Canvas rendering layers bound to `requestAnimationFrame`, creates heavy and continuous Garbage Collection overhead, increasing the chance of UI jank.
 **Action:** When a method returns newly instantiated objects inside a render loop, refactor it to accept an `out` parameter object. Mutate and return this cached pre-allocated object to drastically reduce memory allocation spikes.
+
+## 2025-05-19 - [Optimize DOM Rect Calculations in Render Loops]
+
+**Learning:** Calling `getBoundingClientRect()` or accessing `offsetHeight` inside a `requestAnimationFrame` loop (e.g., drawing row hover effects on a canvas 60fps) forces synchronous layout recalculations (layout thrashing) on every frame. This completely blocks the main thread and causes severe stuttering.
+**Action:** Replace synchronous DOM layout queries in animation loops with pre-calculated, cached dimensions computed once during layout/initialization (or via ResizeObserver). Only read from these cached properties inside the render function.

--- a/js/ui/tableGlassEffect.js
+++ b/js/ui/tableGlassEffect.js
@@ -324,13 +324,11 @@ export class TableGlassEffect {
     }
 
     // Get the position of the row relative to the canvas
-    // We use getBoundingClientRect for both to ensure 1:1 visual alignment
-    const canvasRect = this.canvas.getBoundingClientRect();
-    const rowRect = row.element.getBoundingClientRect();
-
-    // Calculate Y relative to the canvas origin (0,0 of the drawing context)
-    const rowTopRelativeToCanvas = rowRect.top - canvasRect.top;
-    const actualHeight = row.element.offsetHeight;
+    // Bolt: Use pre-calculated row positions (row.top, row.height) instead of
+    // getBoundingClientRect() and offsetHeight to prevent synchronous layout
+    // thrashing during the requestAnimationFrame render loop.
+    const rowTopRelativeToCanvas = row.top;
+    const actualHeight = row.height;
 
     const settings = this.options.rowHoverEffect;
 


### PR DESCRIPTION
### 💡 What
Replaced `getBoundingClientRect` and `offsetHeight` calls with pre-calculated `row.top` and `row.height` properties within the `drawRowHoverEffect` render loop.

### 🎯 Why
Calling `getBoundingClientRect()` and `offsetHeight` inside a `requestAnimationFrame` loop forces the browser to synchronously recalculate layout on every frame (layout thrashing), which severely degrades UI performance and blocks the main thread.

### 📊 Impact
Eliminates layout recalculations during the 60fps render loop, resulting in significantly smoother animations and reduced main thread blocking when interacting with the table glass effect.

### 🔬 Measurement
Verify the improvement by enabling paint/layout profiling in Chrome DevTools Performance tab and observing the absence of forced synchronous layouts during table hover interactions.

---
*PR created automatically by Jules for task [11770149276815930685](https://jules.google.com/task/11770149276815930685) started by @ryusoh*