### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace innerHTML with native DOM methods in chart legends

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -137,3 +137,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Several API integrations using Python's `requests` library lacked a `timeout` parameter.
 **Learning:** External network calls without explicit timeouts can cause the application thread to hang indefinitely, resulting in DoS vulnerabilities or unresponsive applications when the external service is slow or unresponsive.
 **Prevention:** Always include a `timeout` parameter (e.g., `timeout=10`) wrapped within a `try...except requests.exceptions.RequestException` block when using the `requests` library to interact with external services.
+
+## 2024-05-13 - Prevent DOM-based XSS by removing `innerHTML` in chart legends
+
+**Vulnerability:** In `js/commands/retention.js`, `js/commands/due.js`, and `js/commands/reviews.js`, chart legends were constructed by interpolating data into HTML template strings and injecting them into the DOM using `legend.innerHTML = ...`.
+**Learning:** Constructing DOM nodes with string concatenation and `innerHTML` bypasses modern framework protections and trains developers to use unsafe DOM APIs. If a user can inject a malicious payload into a deck name or chart label, it could be executed.
+**Prevention:** When dynamically rendering and constructing HTML structures, always use safe native DOM methods like `document.createElement()`, `element.textContent`, and `element.replaceChildren()` instead of template strings assigned to `innerHTML`.


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Replace innerHTML with native DOM methods in chart legends

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** DOM-based XSS via `innerHTML` assignment. In `js/commands/retention.js`, `js/commands/due.js`, and `js/commands/reviews.js`, chart legends were constructed using template strings containing deck names and styles, then injected directly into the DOM using `legend.innerHTML = ...`. While some variables were escaped, using `innerHTML` for structural DOM generation violates strict secure coding standards and introduces significant risks of accidental XSS regressions.
🎯 **Impact:** If `escapeHtml` is accidentally removed or bypassed, an attacker could supply a malicious payload within a configuration property or deck name that gets executed when the legend renders, leading to Cross-Site Scripting (XSS).
🔧 **Fix:** Refactored all `innerHTML` assignments for chart legends to use safe, native DOM construction APIs (`document.createElement`, `document.createTextNode`, and `replaceChildren`). Also updated the `MockElement` implementation in `tests/legend.test.cjs` and plain mocks in other test files to support these DOM methods so tests continue to function.
✅ **Verification:** Ran `node tools/node_test_runner.mjs` test suite, resulting in 40/40 passing test suites. Added a journal entry to `.jules/sentinel.md` noting the vulnerability and the `replaceChildren` pattern.

---
*PR created automatically by Jules for task [16203972864390056309](https://jules.google.com/task/16203972864390056309) started by @ryusoh*