### PR TITLE
Bolt: Cache Canvas gradient in TableGlassEffect

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -152,3 +152,8 @@
 
 **Learning:** Re-instantiating small objects (like `{ x, y }` points) and mapping intermediate Arrays (`new Array(N)`) inside high-frequency execution loops, such as `gsap.ticker` or `requestAnimationFrame` render layers, creates heavy and continuous Garbage Collection overhead, increasing the chance of UI jank.
 **Action:** When calculating positions or distances inside a render loop, refactor it to pre-allocate an array of `{ x, y }` objects. Mutate and read these cached pre-allocated objects iteratively to drastically reduce memory allocation spikes.
+
+## 2025-05-19 - [Optimize Gradient allocations in Render Check Loops]
+
+**Learning:** Re-instantiating Canvas gradients using `createLinearGradient()` inside high-frequency execution loops, such as `requestAnimationFrame` render layers, creates heavy and continuous Garbage Collection overhead and unneeded CPU burn.
+**Action:** Cache the Canvas gradients on the class instance. Calculate the gradients during layout initializations or `resize` events, and read the cached gradient references iteratively inside the render loop to drastically reduce memory allocation spikes.

--- a/js/ui/tableGlassEffect.js
+++ b/js/ui/tableGlassEffect.js
@@ -193,6 +193,9 @@ export class TableGlassEffect {
     this.canvas.height = this.height * dpr;
     this.ctx.scale(dpr, dpr);
 
+    // Bolt: Invalidate cached ambient glow gradient since canvas dimensions have changed
+    this._ambientGradientCache = null;
+
     // Track rows for hover effect
     this.rows = [];
     if (this.options.rowHoverEffect?.enabled) {
@@ -530,18 +533,20 @@ export class TableGlassEffect {
     this.drawPath(this.ctx, radius);
     this.ctx.clip();
 
-    // Inner glow
-    const gradient = this.ctx.createLinearGradient(
-      0,
-      0,
-      this.width,
-      this.height,
-    );
-    gradient.addColorStop(0, glow.innerColor || "rgba(118, 183, 229, 0.2)");
-    gradient.addColorStop(1, "rgba(0,0,0,0)");
+    // Bolt: Cache Canvas gradients to eliminate heavy object allocations in the high-frequency render loop
+    if (!this._ambientGradientCache) {
+      this._ambientGradientCache = this.ctx.createLinearGradient(
+        0,
+        0,
+        this.width,
+        this.height,
+      );
+      this._ambientGradientCache.addColorStop(0, glow.innerColor || "rgba(118, 183, 229, 0.2)");
+      this._ambientGradientCache.addColorStop(1, "rgba(0,0,0,0)");
+    }
 
     this.ctx.globalAlpha = (glow.innerOpacity || 0.15) * (0.8 + pulse * 0.2);
-    this.ctx.fillStyle = gradient;
+    this.ctx.fillStyle = this._ambientGradientCache;
     this.ctx.fill();
     this.ctx.restore();
   }


### PR DESCRIPTION
What: The optimization implemented caches the Canvas LinearGradient inside the `drawAmbientGlow` function of `TableGlassEffect`, invalidating it only when `resize()` changes the canvas dimensions.
Why: Re-creating `LinearGradient` objects and setting color stops on every single frame of a 60fps `requestAnimationFrame` loop creates severe Garbage Collection (GC) pressure and unnecessary CPU usage.
Impact: Reduces GC spikes and CPU overhead during table hover or continuous ambient animations by recycling the gradient object.
Measurement: This can be verified by observing the Memory tab in Chrome DevTools or running rendering benchmarks, which will show reduced object allocations on the heap per animation frame.

---
*PR created automatically by Jules for task [5666305677651040533](https://jules.google.com/task/5666305677651040533) started by @ryusoh*