### PR TITLE
Palette: Add keyboard support to interactive table headers

### DIFF
--- a/js/ui/table_keyboard_nav.js
+++ b/js/ui/table_keyboard_nav.js
@@ -1,0 +1,17 @@
+export function initTableKeyboardNav() {
+  const headers = document.querySelectorAll("th.sortable, th.filterable");
+  headers.forEach((header) => {
+    header.setAttribute("role", "button");
+    if (!header.hasAttribute("tabindex")) {
+      header.setAttribute("tabindex", "0");
+    }
+    header.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        header.click();
+      }
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initTableKeyboardNav);

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -296,6 +296,7 @@
     <!-- .app-content -->
 
     <script src="../js/ui/scroll_control.js?v=2"></script>
+    <script type="module" src="../js/ui/table_keyboard_nav.js"></script>
     <script
       src="../js/terminal.js?v=20240223"
       type="module"


### PR DESCRIPTION
Added `role="button"`, `tabindex="0"`, and `keydown` event listener for table headers in terminal to support keyboard navigation. Tested thoroughly locally.

---
*PR created automatically by Jules for task [7114431926250928915](https://jules.google.com/task/7114431926250928915) started by @ryusoh*