### PR TITLE
Bolt: Cache THREE vectors in graph animation loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -162,3 +162,8 @@
 
 **Learning:** Re-instantiating Canvas gradients using `createLinearGradient()` inside high-frequency execution loops, such as `requestAnimationFrame` render layers, creates heavy and continuous Garbage Collection overhead and unneeded CPU burn.
 **Action:** Cache the Canvas gradients on the class instance. Calculate the gradients during layout initializations or `resize` events, and read the cached gradient references iteratively inside the render loop to drastically reduce memory allocation spikes.
+
+## 2025-05-20 - [Optimize Object allocations in Three.js Render Loops]
+
+**Learning:** Re-instantiating `THREE.Vector3` objects inside high-frequency execution loops, such as `requestAnimationFrame` render layers, creates heavy and continuous Garbage Collection overhead, increasing the chance of UI jank.
+**Action:** Pre-allocate vectors outside of the render loop and reuse them inside the loop, relying on methods that overwrite values instead of returning new objects.

--- a/js/graph/graph.js
+++ b/js/graph/graph.js
@@ -687,6 +687,12 @@ setTimeout(() => {
 }, 200);
 // --- INTERACTION & NAVIGATION ---
 const keyState = {};
+
+// Bolt: Hoist Vector3 allocations outside the requestAnimationFrame loop
+// to prevent 120 object instantiations per second and reduce GC pressure.
+const _forward = new THREE.Vector3();
+const _right = new THREE.Vector3();
+
 window.addEventListener("keydown", (e) => {
   keyState[e.key] = true;
   if (!historyData) return;
@@ -717,11 +723,9 @@ function animate() {
 
   // WASD Camera Move
   const speed = 25;
-  const forward = new THREE.Vector3();
-  camera.getWorldDirection(forward);
-  const right = new THREE.Vector3()
-    .crossVectors(forward, camera.up)
-    .normalize();
+  camera.getWorldDirection(_forward);
+  _right.crossVectors(_forward, camera.up).normalize();
+
   if (keyState["w"]) {
     camera.position.addScaledVector(camera.up, speed);
     controls.target.addScaledVector(camera.up, speed);
@@ -731,12 +735,12 @@ function animate() {
     controls.target.addScaledVector(camera.up, -speed);
   }
   if (keyState["a"]) {
-    camera.position.addScaledVector(right, -speed);
-    controls.target.addScaledVector(right, -speed);
+    camera.position.addScaledVector(_right, -speed);
+    controls.target.addScaledVector(_right, -speed);
   }
   if (keyState["d"]) {
-    camera.position.addScaledVector(right, speed);
-    controls.target.addScaledVector(right, speed);
+    camera.position.addScaledVector(_right, speed);
+    controls.target.addScaledVector(_right, speed);
   }
 
   controls.update();


### PR DESCRIPTION
💡 **What**: Cached `THREE.Vector3` instances in the `animate` loop of `js/graph/graph.js`.
🎯 **Why**: To prevent 120 vector instantiations per second (2 allocations per frame * 60 FPS), which puts heavy pressure on garbage collection and contributes to UI jank.
📊 **Impact**: Eliminates recurring garbage collection overhead in the high-frequency animation layer, contributing to a smoother rendering experience.
🔬 **Measurement**: Check memory profiling traces to verify the lack of periodic garbage collection spikes during the animate loop.

---
*PR created automatically by Jules for task [11560582242479507032](https://jules.google.com/task/11560582242479507032) started by @ryusoh*