### PR TITLE
Bolt: Replace elementFromPoint with O(1) WeakMap lookup for table hover

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -167,3 +167,8 @@
 
 **Learning:** Re-instantiating `THREE.Vector3` objects inside high-frequency execution loops, such as `requestAnimationFrame` render layers, creates heavy and continuous Garbage Collection overhead, increasing the chance of UI jank.
 **Action:** Pre-allocate vectors outside of the render loop and reuse them inside the loop, relying on methods that overwrite values instead of returning new objects.
+
+## 2025-05-20 - [O(1) Table Row Hover Lookup]
+
+**Learning:** In applications where table rows have hover effects driven by mouse tracking, continuously resolving hovered rows via `document.elementFromPoint(e.clientX, e.clientY)` followed by an O(N) `findIndex` lookup over row collections causes severe layout thrashing and main-thread blocking, particularly with large datasets.
+**Action:** Always prefer retrieving the interacted element via `e.target` directly in mouse events. Pair this with a `WeakMap` during initialization to associate DOM nodes to their corresponding index or metadata for O(1) constant-time lookup instead of iterating through arrays.

--- a/js/ui/tableGlassEffect.js
+++ b/js/ui/tableGlassEffect.js
@@ -198,6 +198,7 @@ export class TableGlassEffect {
 
     // Track rows for hover effect
     this.rows = [];
+    this.rowMap = new WeakMap();
     if (this.options.rowHoverEffect?.enabled) {
       const tbody = this.container.querySelector("tbody");
       if (tbody) {
@@ -206,7 +207,11 @@ export class TableGlassEffect {
         // We need the canvas position to calculate relative row offsets accurately
         const canvasRect = this.canvas.getBoundingClientRect();
 
-        rows.forEach((row) => {
+        // Bolt: Use native for loop and pre-allocate the array to avoid
+        // dummy object creations and callback allocation garbage collection pressure
+        this.rows = new Array(rows.length);
+        for (let i = 0; i < rows.length; i++) {
+          const row = rows[i];
           const rowRect = row.getBoundingClientRect();
 
           // Calculate top relative to the canvas itself
@@ -214,12 +219,13 @@ export class TableGlassEffect {
           // we simply ask "where is the row relative to the canvas?"
           const relativeTop = rowRect.top - canvasRect.top;
 
-          this.rows.push({
+          this.rows[i] = {
             top: relativeTop,
             height: rowRect.height,
             element: row,
-          });
-        });
+          };
+          this.rowMap.set(row, i);
+        }
       }
     }
   }
@@ -232,22 +238,18 @@ export class TableGlassEffect {
 
     // Determine hovered row by finding actual element under cursor
     if (this.options.rowHoverEffect?.enabled) {
-      // Find the actual row element under the mouse cursor
-      const elementUnderMouse = document.elementFromPoint(e.clientX, e.clientY);
+      // Bolt: Use e.target directly instead of the costly document.elementFromPoint
+      // which causes layout thrashing and main thread blocking.
+      const elementUnderMouse = e.target;
       if (elementUnderMouse) {
         // Find the closest table row
         const rowElement = elementUnderMouse.closest("tr");
 
         if (rowElement && this.container.contains(rowElement)) {
-          // Find the index of this row in our stored rows array
-          let foundIndex = -1;
-          for (let i = 0; i < this.rows.length; i++) {
-            if (this.rows[i].element === rowElement) {
-              foundIndex = i;
-              break;
-            }
-          }
-          this.state.hoveredRowIndex = foundIndex;
+          // Bolt: Use WeakMap for O(1) constant-time lookup instead of O(N) array iteration
+          const foundIndex = this.rowMap.get(rowElement);
+          this.state.hoveredRowIndex =
+            foundIndex !== undefined ? foundIndex : -1;
         } else {
           this.state.hoveredRowIndex = -1;
         }


### PR DESCRIPTION
💡 What: Implemented O(1) constant-time row lookup via `WeakMap` and replaced `document.elementFromPoint` layout thrashing with `e.target` in the hover detection logic.
🎯 Why: In high-frequency mouse tracking, iterating over rows for `findIndex` and using hit-testing via `document.elementFromPoint` blocks the main thread and causes UI jank.
📊 Impact: Reduces computational complexity from O(N) to O(1) on every mouse move iteration, completely removing synchronous hit-testing layout calculations.
🔬 Measurement: Verify by executing table glass hover animations smoothly and analyzing the DevTools Performance trace to ensure zero forced reflows during mouse movements.

---
*PR created automatically by Jules for task [15246348219487338562](https://jules.google.com/task/15246348219487338562) started by @ryusoh*