### PR TITLE
Palette: Fix table header accessibility by preserving columnheader role

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -55,3 +55,8 @@
 
 **Learning:** When making table headers (`th` elements) sortable, overriding their inherent `columnheader` role by adding `role="button"` breaks their ability to convey sorting state to screen readers. `aria-sort` is only a valid attribute on elements with `columnheader` or `rowheader` roles.
 **Action:** Do not use `role="button"` on interactive `th` elements. Instead, apply `tabindex="0"` for keyboard accessibility and initialize them with `aria-sort="none"` (or `ascending`/`descending` as appropriate) to correctly expose the sortable semantics and state.
+
+## 2026-05-16 - ARIA Sort States on Table Headers Fix
+
+**Learning:** When making table headers (`th` elements) sortable, overriding their inherent `columnheader` role by adding `role="button"` breaks their ability to convey sorting state to screen readers. `aria-sort` is only a valid attribute on elements with `columnheader` or `rowheader` roles.
+**Action:** Do not use `role="button"` on interactive `th` elements. Instead, apply `tabindex="0"` for keyboard accessibility and initialize them with `aria-sort="none"` (or `ascending`/`descending` as appropriate) to correctly expose the sortable semantics and state.

--- a/js/ui/table_keyboard_nav.js
+++ b/js/ui/table_keyboard_nav.js
@@ -1,10 +1,14 @@
 export function initTableKeyboardNav() {
   const headers = document.querySelectorAll("th.sortable, th.filterable");
   headers.forEach((header) => {
-    header.setAttribute("role", "button");
     if (!header.hasAttribute("tabindex")) {
       header.setAttribute("tabindex", "0");
     }
+
+    if (header.classList.contains("sortable") && !header.hasAttribute("aria-sort")) {
+      header.setAttribute("aria-sort", "none");
+    }
+
     header.addEventListener("keydown", (e) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();


### PR DESCRIPTION
💡 What: Removed `role="button"` from table headers and added `aria-sort="none"` to sortable headers.
🎯 Why: Setting `role="button"` on `th` elements overrides their native `columnheader` role, which invalidates the `aria-sort` attribute used by screen readers to announce sort states.
♿ Accessibility: Preserves table semantics for screen readers while correctly exposing sortable semantics and state.

---
*PR created automatically by Jules for task [10178610479453748825](https://jules.google.com/task/10178610479453748825) started by @ryusoh*