### PR TITLE
Bolt: Cache character bounds in marquee animation to prevent layout thrashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -177,3 +177,8 @@
 
 **Learning:** Calling getBoundingClientRect() and querySelector() inside high-frequency UI events like mousemove causes layout thrashing and unnecessary O(N) DOM query overhead.
 **Action:** Always pre-calculate element associations and cache layout dimensions on mouseenter to guarantee O(1) performance and avoid main-thread blocking during interactions.
+
+## 2025-05-21 - [Optimize getBoundingClientRect in GSAP Ticker]
+
+**Learning:** Calling `getBoundingClientRect()` on multiple child elements inside a high-frequency `gsap.ticker` render loop causes severe layout thrashing and main-thread blocking, drastically dropping the framerate of UI animations.
+**Action:** Pre-calculate and cache the static positions or relative offsets of child elements outside the ticker loop. Inside the loop, only query the single parent container's `getBoundingClientRect()` to compute absolute positions dynamically.

--- a/js/ui/marquee.js
+++ b/js/ui/marquee.js
@@ -103,11 +103,26 @@ function initGravitationalDistortion(widget, charGroups) {
   } = GRAVITY;
   const radiusSq = influenceRadius * influenceRadius;
 
-  // Bolt: Pre-allocate positions cache to avoid object and array creation GC pressure in hot path
+  // Bolt: Pre-calculate static character positions relative to their parent container
+  // to avoid calling O(N) getBoundingClientRect() inside the gsap.ticker animation loop,
+  // which causes severe layout thrashing and main-thread blocking.
   charGroups.forEach((group) => {
-    group.cachedPositions = new Array(group.spans.length);
+    if (group.spans.length === 0) return;
+
+    // The wrapper that moves horizontally (e.g. .marquee-content)
+    const container = group.spans[0].parentElement;
+    group.container = container;
+
+    // We cache their static offsets relative to the parent container
+    const containerRect = container.getBoundingClientRect();
+    group.cachedRelativePositions = new Array(group.spans.length);
+
     for (let i = 0; i < group.spans.length; i++) {
-      group.cachedPositions[i] = { x: 0, y: 0 };
+      const r = group.spans[i].getBoundingClientRect();
+      group.cachedRelativePositions[i] = {
+        xOffset: (r.left + r.width / 2) - containerRect.left,
+        yOffset: (r.top + r.height / 2) - containerRect.top
+      };
     }
   });
 
@@ -119,18 +134,19 @@ function initGravitationalDistortion(widget, charGroups) {
     const wcx = wRect.left + wRect.width / 2;
     const wcy = wRect.top + wRect.height / 2;
 
-    for (const { spans, direction, cachedPositions } of charGroups) {
-      // Batch read all positions first to avoid layout thrashing
-      for (let i = 0; i < spans.length; i += 1) {
-        const r = spans[i].getBoundingClientRect();
-        cachedPositions[i].x = r.left + r.width / 2;
-        cachedPositions[i].y = r.top + r.height / 2;
-      }
+    for (const { spans, direction, cachedRelativePositions, container } of charGroups) {
+      // We only query the parent container's moving bounds once per frame
+      const containerRect = container.getBoundingClientRect();
+      const cLeft = containerRect.left;
+      const cTop = containerRect.top;
 
-      // Batch write transforms
+      // Batch write transforms based on dynamically computed absolute positions
       for (let i = 0; i < spans.length; i += 1) {
-        const dx = wcx - cachedPositions[i].x;
-        const dy = wcy - cachedPositions[i].y;
+        const absX = cLeft + cachedRelativePositions[i].xOffset;
+        const absY = cTop + cachedRelativePositions[i].yOffset;
+
+        const dx = wcx - absX;
+        const dy = wcy - absY;
         const distSq = dx * dx + dy * dy;
 
         if (distSq >= radiusSq || distSq < 1) {


### PR DESCRIPTION
💡 **What:** Caches character relative offsets in Marquee's `initGravitationalDistortion` loop.
🎯 **Why:** To eliminate O(N) `getBoundingClientRect` DOM queries inside the 60fps `gsap.ticker` callback, preventing severe layout thrashing and main-thread locking.
📊 **Impact:** Reduces DOM read operations from hundreds per frame to exactly 1 per text group per frame, drastically increasing render performance.
🔬 **Measurement:** Confirmed layout changes using simulated DOM mocks and ensured `gsap.ticker` tests still pass smoothly without performance bottlenecks.

---
*PR created automatically by Jules for task [18115251213674976106](https://jules.google.com/task/18115251213674976106) started by @ryusoh*