### PR TITLE
Palette: Hide decorative icons from screen readers in navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -60,3 +60,8 @@
 
 **Learning:** When making table headers (`th` elements) sortable, overriding their inherent `columnheader` role by adding `role="button"` breaks their ability to convey sorting state to screen readers. `aria-sort` is only a valid attribute on elements with `columnheader` or `rowheader` roles.
 **Action:** Do not use `role="button"` on interactive `th` elements. Instead, apply `tabindex="0"` for keyboard accessibility and initialize them with `aria-sort="none"` (or `ascending`/`descending` as appropriate) to correctly expose the sortable semantics and state.
+
+## 2024-06-08 - Screen Reader Redundancy with Icon Links
+
+**Learning:** FontAwesome icons (`<i class="fa ...">`) placed inside semantic interactive elements like `<a aria-label="...">` are often read out loud by screen readers as arbitrary Unicode characters or irrelevant text, which adds confusing noise and redundancy when an `aria-label` already perfectly describes the element's purpose.
+**Action:** Always explicitly hide decorative or redundant icon elements from screen readers by adding `aria-hidden="true"` to the `<i>` or `<svg>` tag when the parent interactive element already provides an adequate accessible name via `aria-label` or text content.

--- a/graph/index.html
+++ b/graph/index.html
@@ -66,17 +66,17 @@
       <ul>
         <li>
           <a href="/" aria-label="Home">
-            <i class="fa fa-chevron-right"></i>
+            <i class="fa fa-chevron-right" aria-hidden="true"></i>
           </a>
         </li>
         <li class="is-current-page">
           <a href="/graph/" aria-label="Graph">
-            <i class="fa fa-connectdevelop"></i>
+            <i class="fa fa-connectdevelop" aria-hidden="true"></i>
           </a>
         </li>
         <li>
           <a href="/terminal/" aria-label="Terminal">
-            <i class="fa fa-code"></i>
+            <i class="fa fa-code" aria-hidden="true"></i>
           </a>
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -173,12 +173,12 @@
           </li>
           <li>
             <a href="/graph/" aria-label="Graph">
-              <i class="fa fa-connectdevelop"></i>
+              <i class="fa fa-connectdevelop" aria-hidden="true"></i>
             </a>
           </li>
           <li>
             <a href="/terminal/" aria-label="Terminal">
-              <i class="fa fa-code"></i>
+              <i class="fa fa-code" aria-hidden="true"></i>
             </a>
           </li>
         </ul>

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -161,17 +161,17 @@
         <ul>
           <li>
             <a href="../" aria-label="Home">
-              <i class="fa fa-chevron-right"></i>
+              <i class="fa fa-chevron-right" aria-hidden="true"></i>
             </a>
           </li>
           <li>
             <a href="../graph/" aria-label="Graph">
-              <i class="fa fa-connectdevelop"></i>
+              <i class="fa fa-connectdevelop" aria-hidden="true"></i>
             </a>
           </li>
           <li class="is-current-page">
             <a href="./" aria-label="Terminal">
-              <i class="fa fa-code"></i>
+              <i class="fa fa-code" aria-hidden="true"></i>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
This PR adds the `aria-hidden="true"` attribute to decorative FontAwesome icons located inside navigation links across the application's root, graph, and terminal index pages. 

Because the parent anchor tags already provide an explicit and accessible name via `aria-label` (e.g., "Terminal"), screen readers were additionally reading out the unhelpful characters associated with the font icons. By explicitly hiding these decorative icons from the accessibility tree, we reduce screen reader noise and ensure a cleaner auditory experience.

A corresponding entry has also been appended to the Palette learning journal.

---
*PR created automatically by Jules for task [2549673003647068256](https://jules.google.com/task/2549673003647068256) started by @ryusoh*