### PR TITLE
Sentinel: [MEDIUM] Add timeout to external API requests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -161,3 +161,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Dynamic chart legends in `js/commands/retention.js`, `js/commands/due.js`, and `js/commands/reviews.js` were using string concatenation assigned to `legend.innerHTML`. Even though user inputs like deck names were escaped, this pattern violated defense-in-depth secure coding principles.
 **Learning:** Assigning dynamically built strings to `innerHTML`—even with escaped variables—violates modern SAST rules and risks accidental XSS introduction during future modifications. Safe DOM APIs should be the standard everywhere.
 **Prevention:** Always use safe DOM manipulation methods like `document.createElement`, `document.createTextNode`, and `appendChild` when building HTML structures, and use `element.textContent = ""` or `element.replaceChildren()` to clear elements securely instead of `element.innerHTML = ""`.
+
+## 2024-05-24 - Prevent Denial of Service by adding timeouts to urlopen calls
+
+**Vulnerability:** External HTTP requests made using `urllib.request.urlopen` in `awesome_tts/awesometts/service/baidu.py`, `awesome_tts/awesometts/service/naverclova.py`, and `awesome_tts/awesometts/service/naverclovapremium.py` lacked a `timeout` parameter.
+**Learning:** Making network calls to external APIs without specifying an explicit timeout allows the application thread to block indefinitely if the remote server hangs or is unresponsive, leading to application freezes and Denial of Service (DoS) vulnerabilities.
+**Prevention:** Always include a explicit `timeout` parameter (e.g., `timeout=10`) when invoking `urlopen()` or any other external network request method in Python.

--- a/awesome_tts/awesometts/service/baidu.py
+++ b/awesome_tts/awesometts/service/baidu.py
@@ -184,7 +184,7 @@ class Baidu(Service):
         
         post_data = urlencode(params).encode('utf-8')
         req = Request('http://tsn.baidu.com/text2audio', post_data)
-        audio_content = urlopen(req).read()
+        audio_content = urlopen(req, timeout=10).read()
         
         if options['encoding'] == 3:
             # Write MP3 audio content direct to file

--- a/awesome_tts/awesometts/service/naverclova.py
+++ b/awesome_tts/awesometts/service/naverclova.py
@@ -100,7 +100,7 @@ class NaverClova(Service):
         request = urllib.request.Request(url)
         request.add_header("X-NCP-APIGW-API-KEY-ID",client_id)
         request.add_header("X-NCP-APIGW-API-KEY",client_secret)
-        response = urllib.request.urlopen(request, data=data.encode('utf-8'))
+        response = urllib.request.urlopen(request, data=data.encode('utf-8'), timeout=10)
         rescode = response.getcode()
         if(rescode==200):
             self._logger.debug("successful response")

--- a/awesome_tts/awesometts/service/naverclovapremium.py
+++ b/awesome_tts/awesometts/service/naverclovapremium.py
@@ -137,7 +137,7 @@ class NaverClovaPremium(Service):
             request = urllib.request.Request(url)
             request.add_header("X-NCP-APIGW-API-KEY-ID",client_id)
             request.add_header("X-NCP-APIGW-API-KEY",client_secret)
-            response = urllib.request.urlopen(request, data=data.encode('utf-8'))
+            response = urllib.request.urlopen(request, data=data.encode('utf-8'), timeout=10)
             rescode = response.getcode()
             if(rescode==200):
                 self._logger.debug("successful response")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `timeout` parameter on `urllib.request.urlopen` external API calls.
🎯 Impact: If the third-party API server hangs or fails to respond, the application thread blocks indefinitely, leading to application freezes and resource exhaustion (Denial of Service).
🔧 Fix: Added `timeout=10` to `urlopen` calls in `baidu.py`, `naverclova.py`, and `naverclovapremium.py`.
✅ Verification: Tested via Python test suite (`make check-py`).

---
*PR created automatically by Jules for task [4724927993979489258](https://jules.google.com/task/4724927993979489258) started by @ryusoh*