### PR TITLE
Bolt: cache translated radial gradients to eliminate GC pressure

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -187,3 +187,8 @@
 
 **Learning:** Calling `getBoundingClientRect()` directly inside high-frequency `mousemove` event listeners causes layout thrashing and main thread blocking, as it forces the browser to synchronously recalculate layout on every mouse movement. This leads to dropped frames and severe performance degradation for continuous interactive effects like the magnetic thumb effect.
 **Action:** Always pre-calculate and cache the bounding rectangle dimensions via `getBoundingClientRect()` on the `mouseenter` event, and reuse those cached dimensions during `mousemove`. Invalidate the cache on `mouseleave` to assure positional accuracy upon the next interaction without paying the continuous layout calculation cost.
+
+## 2026-05-24 - [Optimize radial gradient allocations in render loops]
+
+**Learning:** Instantiating new `CanvasGradient` objects via `createRadialGradient()` inside high-frequency animation loops (like `requestAnimationFrame`) creates heavy garbage collection (GC) overhead. If the gradient moves dynamically (e.g., following a mouse pointer), caching it at static coordinates doesn't work.
+**Action:** Create and cache the gradient object centered at `(0, 0)` during initialization or resize. Inside the render loop, use `ctx.translate()` to move the canvas context to the dynamic target coordinates, draw the shape using the cached gradient relative to the translated origin, and then call `ctx.restore()`. This completely eliminates gradient object allocation overhead on every frame.

--- a/js/ui/tableGlassEffect.js
+++ b/js/ui/tableGlassEffect.js
@@ -195,6 +195,8 @@ export class TableGlassEffect {
 
     // Bolt: Invalidate cached ambient glow gradient since canvas dimensions have changed
     this._ambientGradientCache = null;
+    this._hoverSpotlightGradientCache = null;
+    this._hoverBorderGradientCache = null;
 
     // Track rows for hover effect
     this.rows = [];
@@ -347,53 +349,38 @@ export class TableGlassEffect {
     const mouseX = ((this.state.pointer.x + 1) / 2) * this.width;
     const spotlightRadius = settings.spotlightRadius || 300;
 
-    // 1. Spotlight Background (Radial Gradient)
-    // Center the gradient on the mouse X, but vertically centered on the row
-    const gradient = this.ctx.createRadialGradient(
-      mouseX,
-      rowTopRelativeToCanvas + actualHeight / 2,
-      0,
-      mouseX,
-      rowTopRelativeToCanvas + actualHeight / 2,
-      spotlightRadius,
-    );
+    // Bolt: Cache radial gradients centered at (0, 0) to avoid re-instantiating objects on every 60fps frame.
+    // We translate the canvas context to the target coordinates before drawing instead.
+    if (!this._hoverSpotlightGradientCache) {
+      this._hoverSpotlightGradientCache = this.ctx.createRadialGradient(
+        0, 0, 0, 0, 0, spotlightRadius,
+      );
+      this._hoverSpotlightGradientCache.addColorStop(0, settings.color || "rgba(255, 255, 255, 0.05)");
+      this._hoverSpotlightGradientCache.addColorStop(1, "rgba(0, 0, 0, 0)");
 
-    gradient.addColorStop(0, settings.color || "rgba(255, 255, 255, 0.05)");
-    gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
+      this._hoverBorderGradientCache = this.ctx.createRadialGradient(
+        0, 0, 0, 0, 0, spotlightRadius * 0.8,
+      );
+      this._hoverBorderGradientCache.addColorStop(0, settings.borderColor || "rgba(255, 255, 255, 0.2)");
+      this._hoverBorderGradientCache.addColorStop(1, "rgba(0, 0, 0, 0)");
+    }
 
-    this.ctx.fillStyle = gradient;
-    this.ctx.fillRect(0, rowTopRelativeToCanvas, this.width, actualHeight);
+    // Translate context to center of row hover spotlight
+    this.ctx.translate(mouseX, rowTopRelativeToCanvas + actualHeight / 2);
 
-    // 2. Border Reveal (Masked by the same spotlight gradient)
-    // We want the borders to be visible only near the mouse
+    // 1. Spotlight Background
+    this.ctx.fillStyle = this._hoverSpotlightGradientCache;
+    this.ctx.fillRect(-mouseX, -actualHeight / 2, this.width, actualHeight);
 
-    const borderGradient = this.ctx.createRadialGradient(
-      mouseX,
-      rowTopRelativeToCanvas + actualHeight / 2,
-      0,
-      mouseX,
-      rowTopRelativeToCanvas + actualHeight / 2,
-      spotlightRadius * 0.8,
-    );
-    borderGradient.addColorStop(
-      0,
-      settings.borderColor || "rgba(255, 255, 255, 0.2)",
-    );
-    borderGradient.addColorStop(1, "rgba(0, 0, 0, 0)");
-
-    this.ctx.strokeStyle = borderGradient;
+    // 2. Border Reveal
+    this.ctx.strokeStyle = this._hoverBorderGradientCache;
     this.ctx.lineWidth = 1;
 
-    // Top border
     this.ctx.beginPath();
-    this.ctx.moveTo(0, rowTopRelativeToCanvas);
-    this.ctx.lineTo(this.width, rowTopRelativeToCanvas);
-    this.ctx.stroke();
-
-    // Bottom border
-    this.ctx.beginPath();
-    this.ctx.moveTo(0, rowTopRelativeToCanvas + actualHeight);
-    this.ctx.lineTo(this.width, rowTopRelativeToCanvas + actualHeight);
+    this.ctx.moveTo(-mouseX, -actualHeight / 2);
+    this.ctx.lineTo(this.width - mouseX, -actualHeight / 2);
+    this.ctx.moveTo(-mouseX, actualHeight / 2);
+    this.ctx.lineTo(this.width - mouseX, actualHeight / 2);
     this.ctx.stroke();
 
     this.ctx.restore();


### PR DESCRIPTION
💡 What: Refactored `drawRowHoverEffect` in `js/ui/tableGlassEffect.js` to create and cache `RadialGradient` objects centered at `(0, 0)` during `resize()`. Inside the high-frequency render loop, it now translates the canvas context using `ctx.translate()` to draw the gradients at the dynamic coordinates instead of creating new objects on every frame.
🎯 Why: `createRadialGradient()` was being called continuously inside `requestAnimationFrame` when hovering table rows, generating two new `CanvasGradient` objects every single frame (60fps). This caused severe garbage collection pressure and could lead to UI stuttering and main thread drops.
📊 Impact: Eliminates ~120 complex object allocations per second during hover interaction, completely mitigating GC pressure for this effect without altering functionality.
🔬 Measurement: Verify smooth performance and reduced GC spikes in Chrome DevTools Performance Profiler during rapid table row hovering.

---
*PR created automatically by Jules for task [12567560522976044024](https://jules.google.com/task/12567560522976044024) started by @ryusoh*