### PR TITLE
test: improve python graph module test coverage

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -102,3 +102,8 @@
 
 **Learning:** When testing Python graph analysis utilities that use NetworkX (e.g., `get_hub_nodes` or `get_top_nodes`), instantiate minimal synthetic `nx.DiGraph` objects and directly inject expected node attributes (e.g., `G.add_node('id', pagerank=0.05)`) instead of executing the entire graph building pipeline.
 **Action:** This practice strictly isolates specific analysis logic and ensures reliable boundary testing.
+
+## 2026-05-25 - Unit test coverage improvements
+
+**Learning:** When using `unittest.mock.patch` in Python to mock file operations, always patch `builtins.open` instead of trying to patch `open` on the target module directly (e.g., `@patch('module.open')`), as the latter will raise an AttributeError if `open` was not explicitly imported in that module.
+**Action:** Remember to use `@patch('builtins.open')` across the board to ensure consistent, stable mocking behavior without needing the target module to explicitly import the built-in.

--- a/graph/tests/test_builder.py
+++ b/graph/tests/test_builder.py
@@ -10,6 +10,20 @@ import pytest
 class TestBuildGraph:
     """Test graph building."""
     
+    def test_build_graph_with_anonymization(self):
+        """Test that graph node front and tags are hashed when anonymization is enabled."""
+        from graph.builder import build_graph
+        from graph.tests.fixtures import ENGLISH_NOTES
+
+        G = build_graph(ENGLISH_NOTES, with_anonymization=True)
+
+        # Check that original text is not present in the graph
+        for node, data in G.nodes(data=True):
+            assert 'Note_' in data['front']
+            assert 'Note_' in data['label']
+            assert 'flamboyant' not in data['front'].lower()
+            assert 'vocabulary' not in data['tags'].lower()
+
     def test_build_graph_creates_nodes(self):
         """Test that graph has nodes for all notes."""
         from graph.builder import build_graph

--- a/graph/tests/test_incremental.py
+++ b/graph/tests/test_incremental.py
@@ -1,3 +1,5 @@
+import unittest
+from unittest.mock import patch, MagicMock
 """
 Tests for incremental export system
 """
@@ -140,6 +142,110 @@ class TestIncrementLogic:
         size = 50000
         next_size = size + 5000
         assert next_size == 55000
+
+class TestExportGraph:
+    """Test exporting graph data."""
+
+    @patch('graph.incremental_export.json.dump')
+    @patch('graph.incremental_export.open', new_callable=unittest.mock.mock_open)
+    @patch('graph.incremental_export.build_graph')
+    @patch('graph.incremental_export.json.load')
+    @patch('graph.incremental_export.gzip.open', new_callable=unittest.mock.mock_open)
+    def test_export_graph(self, mock_gzip_open, mock_json_load, mock_build_graph, mock_open, mock_json_dump):
+        """Test export_graph reads notes, builds graph, and writes to DATA_FILE."""
+        from graph.incremental_export import export_graph
+        import networkx as nx
+
+        # Mock json load
+        mock_json_load.return_value = [{'id': '1', 'front': 'Card 1', 'deck': 'Deck A'}]
+
+        # Mock build graph
+        G = nx.DiGraph()
+        G.add_node('1', front='Card 1', deck='Deck A', pagerank=0.5)
+        mock_build_graph.return_value = G
+
+        # Run
+        num_nodes = export_graph(10)
+
+        # Assertions
+        assert num_nodes == 1
+        mock_json_load.assert_called_once()
+        mock_build_graph.assert_called_once()
+        mock_open.assert_called_once()
+        mock_json_dump.assert_called_once()
+
+        # Verify JSON dump structure
+        args, kwargs = mock_json_dump.call_args
+        data = args[0]
+        assert 'nodes' in data
+        assert 'links' in data
+        assert len(data['nodes']) == 1
+        assert data['nodes'][0]['id'] == '1'
+
+class TestMainExecution:
+    """Test main command-line execution."""
+
+    @patch('graph.incremental_export.export_graph')
+    @patch('graph.incremental_export.save_config')
+    @patch('graph.incremental_export.load_config')
+    @patch('sys.argv', ['incremental_export.py', '--status'])
+    def test_main_status(self, mock_load_config, mock_save_config, mock_export_graph):
+        """Test main running with --status flag."""
+        from graph.incremental_export import main
+        mock_load_config.return_value = {'sample_size': 100, 'increment': 100}
+
+        main()
+
+        mock_load_config.assert_called_once()
+        mock_export_graph.assert_not_called()
+
+    @patch('graph.incremental_export.export_graph')
+    @patch('graph.incremental_export.save_config')
+    @patch('graph.incremental_export.load_config')
+    @patch('sys.argv', ['incremental_export.py', '--reset'])
+    def test_main_reset(self, mock_load_config, mock_save_config, mock_export_graph):
+        """Test main running with --reset flag."""
+        from graph.incremental_export import main
+        mock_load_config.return_value = {'sample_size': 500, 'increment': 100}
+
+        main()
+
+        mock_save_config.assert_called_once()
+        saved_config = mock_save_config.call_args[0][0]
+        assert saved_config['sample_size'] == 100
+        mock_export_graph.assert_called_once_with(100)
+
+    @patch('graph.incremental_export.export_graph')
+    @patch('graph.incremental_export.save_config')
+    @patch('graph.incremental_export.load_config')
+    @patch('sys.argv', ['incremental_export.py', '--size', '200'])
+    def test_main_size(self, mock_load_config, mock_save_config, mock_export_graph):
+        """Test main running with --size flag."""
+        from graph.incremental_export import main
+        mock_load_config.return_value = {'sample_size': 100, 'increment': 100}
+
+        main()
+
+        mock_save_config.assert_called_once()
+        saved_config = mock_save_config.call_args[0][0]
+        assert saved_config['sample_size'] == 200
+        mock_export_graph.assert_called_once_with(200)
+
+    @patch('graph.incremental_export.export_graph')
+    @patch('graph.incremental_export.save_config')
+    @patch('graph.incremental_export.load_config')
+    @patch('sys.argv', ['incremental_export.py', '--next'])
+    def test_main_next(self, mock_load_config, mock_save_config, mock_export_graph):
+        """Test main running with --next flag."""
+        from graph.incremental_export import main
+        mock_load_config.return_value = {'sample_size': 100, 'increment': 100}
+
+        main()
+
+        mock_save_config.assert_called_once()
+        saved_config = mock_save_config.call_args[0][0]
+        assert saved_config['sample_size'] == 200
+        mock_export_graph.assert_called_once_with(200)
 
 
 class TestExportValidation:

--- a/graph/tests/test_watch_and_update.py
+++ b/graph/tests/test_watch_and_update.py
@@ -6,6 +6,123 @@ import sys
 from graph.watch_and_update import refresh_browser
 
 class TestWatchAndUpdate(unittest.TestCase):
+    @patch('graph.watch_and_update.CONFIG_FILE')
+    @patch('json.load')
+    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    def test_get_current_size_exists(self, mock_open, mock_json_load, mock_config_file):
+        from graph.watch_and_update import get_current_size
+        mock_config_file.exists.return_value = True
+        mock_json_load.return_value = {'sample_size': 200}
+
+        size = get_current_size()
+        self.assertEqual(size, 200)
+        mock_json_load.assert_called_once()
+        mock_open.assert_called_once()
+
+    @patch('graph.watch_and_update.CONFIG_FILE')
+    def test_get_current_size_default(self, mock_config_file):
+        from graph.watch_and_update import get_current_size
+        mock_config_file.exists.return_value = False
+
+        size = get_current_size()
+        self.assertEqual(size, 100)
+
+    @patch('graph.watch_and_update.subprocess.run')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_increment_success(self, mock_stdout, mock_run):
+        from graph.watch_and_update import increment
+        mock_run.return_value = MagicMock(returncode=0, stdout="Success")
+
+        increment()
+        output = mock_stdout.getvalue()
+
+        self.assertIn("Incrementing...", output)
+        self.assertIn("Success", output)
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        self.assertIn('--next', args[0])
+        self.assertTrue(kwargs.get('capture_output'))
+
+    @patch('graph.watch_and_update.subprocess.run')
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_increment_error(self, mock_stdout, mock_run):
+        from graph.watch_and_update import increment
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error message")
+
+        increment()
+        output = mock_stdout.getvalue()
+
+        self.assertIn("Incrementing...", output)
+        self.assertIn("Error: Error message", output)
+        mock_run.assert_called_once()
+
+    @patch('graph.watch_and_update.increment')
+    @patch('graph.watch_and_update.refresh_browser')
+    @patch('sys.argv', ['watch_and_update.py', '--once', '--auto-refresh'])
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_main_once_auto_refresh(self, mock_stdout, mock_refresh_browser, mock_increment):
+        from graph.watch_and_update import main
+        main()
+
+        mock_increment.assert_called_once()
+        mock_refresh_browser.assert_called_once()
+
+        output = mock_stdout.getvalue()
+        self.assertIn("Watcher started", output)
+
+    @patch('graph.watch_and_update.time.sleep')
+    @patch('graph.watch_and_update.get_current_size')
+    @patch('sys.argv', ['watch_and_update.py', '--max', '200'])
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_main_max_reached(self, mock_stdout, mock_get_current_size, mock_sleep):
+        from graph.watch_and_update import main
+        mock_get_current_size.side_effect = [100, 200]
+
+        main()
+
+        mock_sleep.assert_called_once_with(30)
+        output = mock_stdout.getvalue()
+        self.assertIn("Reached max size: 200", output)
+
+    @patch('graph.watch_and_update.time.sleep')
+    @patch('graph.watch_and_update.get_current_size')
+    @patch('graph.watch_and_update.increment')
+    @patch('sys.argv', ['watch_and_update.py', '--interval', '10'])
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_main_loop_increment(self, mock_stdout, mock_increment, mock_get_current_size, mock_sleep):
+        from graph.watch_and_update import main
+        # First call sets last_size = 100
+        # Second call is in loop, returns 100 (same size) -> increment called
+        # Third call raises KeyboardInterrupt to exit loop
+        mock_get_current_size.side_effect = [100, 100, 100]
+        mock_sleep.side_effect = [None, KeyboardInterrupt()]
+
+        main()
+
+        mock_increment.assert_called_once()
+        output = mock_stdout.getvalue()
+        self.assertIn("Watcher stopped", output)
+
+    @patch('graph.watch_and_update.time.sleep')
+    @patch('graph.watch_and_update.get_current_size')
+    @patch('graph.watch_and_update.increment')
+    @patch('sys.argv', ['watch_and_update.py', '--interval', '10'])
+    @patch('sys.stdout', new_callable=io.StringIO)
+    def test_main_loop_size_changed(self, mock_stdout, mock_increment, mock_get_current_size, mock_sleep):
+        from graph.watch_and_update import main
+        # First call sets last_size = 100
+        # Second call is in loop, returns 200 (changed size) -> skip increment
+        # Third call raises KeyboardInterrupt to exit loop
+        mock_get_current_size.side_effect = [100, 200, 200]
+        mock_sleep.side_effect = [None, KeyboardInterrupt()]
+
+        main()
+
+        mock_increment.assert_not_called()
+        output = mock_stdout.getvalue()
+        self.assertIn("Size changed: 100 → 200", output)
+        self.assertIn("Watcher stopped", output)
+
     @patch('subprocess.run')
     @patch('sys.stdout', new_callable=io.StringIO)
     def test_refresh_browser_success(self, mock_stdout, mock_run):


### PR DESCRIPTION
Added unit test coverage for areas in the `graph` module lacking coverage:
- Added tests for `build_graph` with `with_anonymization=True` to ensure hashing of front field and tags.
- Added comprehensive unit tests for `incremental_export.py` export logic and CLI args mapping by using deep mocks to ensure no side effects.
- Added unit tests to `watch_and_update.py` for its file handling, CLI looping, and size update behaviors.

---
*PR created automatically by Jules for task [12750309981454307434](https://jules.google.com/task/12750309981454307434) started by @ryusoh*