### PR TITLE
Bolt: Optimize high-frequency GSAP animations with quickTo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -192,3 +192,6 @@
 
 **Learning:** Instantiating new `CanvasGradient` objects via `createRadialGradient()` inside high-frequency animation loops (like `requestAnimationFrame`) creates heavy garbage collection (GC) overhead. If the gradient moves dynamically (e.g., following a mouse pointer), caching it at static coordinates doesn't work.
 **Action:** Create and cache the gradient object centered at `(0, 0)` during initialization or resize. Inside the render loop, use `ctx.translate()` to move the canvas context to the dynamic target coordinates, draw the shape using the cached gradient relative to the translated origin, and then call `ctx.restore()`. This completely eliminates gradient object allocation overhead on every frame.
+## 2025-05-25 - Use gsap.quickTo for mousemove events
+**Learning:** Using `gsap.to()` repeatedly inside high-frequency event listeners like `mousemove` instantiates a new tween on every event, leading to significant GC (Garbage Collection) pressure and potential animation jitter.
+**Action:** Always pre-allocate `gsap.quickTo()` functions outside the event listener and invoke them with updated values to reuse the internal GSAP mechanism efficiently.

--- a/js/ui/magnetic_nav.js
+++ b/js/ui/magnetic_nav.js
@@ -19,6 +19,17 @@ export function initMagneticNav() {
     const child = el.querySelector("a, i");
     let rect = null;
 
+    // Pre-allocate gsap quickTo functions to avoid creating new Tweens on every mousemove
+    const xTo = window.gsap.quickTo(el, "x", { duration: 0.3, ease: "power2.out" });
+    const yTo = window.gsap.quickTo(el, "y", { duration: 0.3, ease: "power2.out" });
+
+    let childXTo = null;
+    let childYTo = null;
+    if (child) {
+      childXTo = window.gsap.quickTo(child, "x", { duration: 0.3, ease: "power2.out" });
+      childYTo = window.gsap.quickTo(child, "y", { duration: 0.3, ease: "power2.out" });
+    }
+
     el.addEventListener("mouseenter", () => {
       rect = el.getBoundingClientRect();
     });
@@ -40,21 +51,13 @@ export function initMagneticNav() {
       // Strength of pull factor (lower = less pull)
       const strength = 0.4;
 
-      window.gsap.to(el, {
-        x: distX * strength,
-        y: distY * strength,
-        duration: 0.3,
-        ease: "power2.out",
-      });
+      xTo(distX * strength);
+      yTo(distY * strength);
 
       // Pull the child element (e.g. <a> or <i>) slightly more for a parallax effect
-      if (child) {
-        window.gsap.to(child, {
-          x: distX * (strength * 1.5),
-          y: distY * (strength * 1.5),
-          duration: 0.3,
-          ease: "power2.out",
-        });
+      if (child && childXTo && childYTo) {
+        childXTo(distX * (strength * 1.5));
+        childYTo(distY * (strength * 1.5));
       }
     });
 
@@ -66,6 +69,7 @@ export function initMagneticNav() {
         y: 0,
         duration: 0.7,
         ease: "elastic.out(1, 0.3)",
+        overwrite: true,
       });
 
       if (child) {
@@ -74,6 +78,7 @@ export function initMagneticNav() {
           y: 0,
           duration: 0.7,
           ease: "elastic.out(1, 0.3)",
+          overwrite: true,
         });
       }
     });

--- a/js/ui/tilt_effect.js
+++ b/js/ui/tilt_effect.js
@@ -21,6 +21,10 @@ export function initTiltEffect() {
       transformStyle: "preserve-3d",
     });
 
+    // Pre-allocate gsap quickTo functions to avoid creating new Tweens on every mousemove
+    const rotateXTo = window.gsap.quickTo(container, "rotateX", { duration: 0.5, ease: "power2.out" });
+    const rotateYTo = window.gsap.quickTo(container, "rotateY", { duration: 0.5, ease: "power2.out" });
+
     container.addEventListener("mouseenter", () => {
       rect = container.getBoundingClientRect();
     });
@@ -36,13 +40,9 @@ export function initTiltEffect() {
       const centerY = rect.height / 2;
       const rotateX = ((y - centerY) / centerY) * -10;
       const rotateY = ((x - centerX) / centerX) * 10;
-      window.gsap.to(container, {
-        rotateX: rotateX,
-        rotateY: rotateY,
-        duration: 0.5,
-        ease: "power2.out",
-        overwrite: true,
-      });
+
+      rotateXTo(rotateX);
+      rotateYTo(rotateY);
     });
     container.addEventListener("mouseleave", () => {
       rect = null;


### PR DESCRIPTION
💡 What: Replaced `gsap.to()` inside the `mousemove` event handlers of both `magnetic_nav.js` and `tilt_effect.js` with `gsap.quickTo()`.

🎯 Why: Calling `gsap.to()` dynamically inside a rapid-fire event listener like `mousemove` instantiates a new tween object every time the cursor moves (up to 60 or 120 times per second), creating significant garbage collection overhead and potential jank.

📊 Impact: Reduces memory allocation and tween instantiation in high-frequency event loops from O(N) to O(1).

🔬 Measurement: Use the Chrome DevTools Performance tab. Hover over the magnetic nav links or the tilt containers rapidly. The memory footprint timeline should show fewer GC spikes (sawtooth pattern) compared to before, and the Javascript CPU execution time per frame during hover will be lower.

---
*PR created automatically by Jules for task [17897430221080618742](https://jules.google.com/task/17897430221080618742) started by @ryusoh*