### PR TITLE
Sentinel: [HIGH] Enforce HTTPS for Baidu API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -176,3 +176,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Security audit tool (tools/security_audit.py) flagged its own unit tests as containing hardcoded secrets and private data.
 **Learning:** Static analysis tools that look for explicit string matches for secrets or private data structures will trigger false positives when scanning their own unit tests, as tests necessarily contain mock examples of the exact strings or structures the tool is designed to find.
 **Prevention:** Specifically exclude test directories (e.g., 'tests/') from the security audit scan paths to prevent false positives from mock data, ensuring the audit accurately reflects the state of production code without failing on valid test cases.
+
+## 2024-10-25 - Enforce HTTPS for Baidu API
+
+**Vulnerability:** Unencrypted data transmission (HTTP) was used for Baidu API endpoints (`http://openapi.baidu.com` and `http://tsn.baidu.com`), risking MitM exposure of API credentials, OAuth tokens, and audio data.
+**Learning:** Using HTTP for external APIs, even non-critical ones, exposes sensitive request headers and payload data to interception and tampering, failing defense-in-depth principles.
+**Prevention:** Always enforce HTTPS for any external API requests, especially those exchanging authentication tokens or processing user data.

--- a/awesome_tts/awesometts/service/baidu.py
+++ b/awesome_tts/awesometts/service/baidu.py
@@ -149,7 +149,7 @@ class Baidu(Service):
         
         post_data = urlencode(params).encode('utf-8')
         
-        req = Request('http://openapi.baidu.com/oauth/2.0/token', post_data)
+        req = Request('https://openapi.baidu.com/oauth/2.0/token', post_data)
         result = json.loads(urlopen(req, timeout=5).read().decode())
         
         if 'access_token' in result.keys() and 'scope' in result.keys():
@@ -183,7 +183,7 @@ class Baidu(Service):
         }
         
         post_data = urlencode(params).encode('utf-8')
-        req = Request('http://tsn.baidu.com/text2audio', post_data)
+        req = Request('https://tsn.baidu.com/text2audio', post_data)
         audio_content = urlopen(req, timeout=10).read()
         
         if options['encoding'] == 3:


### PR DESCRIPTION
Severity: HIGH
Vulnerability: Unencrypted data transmission (HTTP) was used for Baidu API endpoints, exposing API keys, OAuth access tokens, and audio data to interception.
Impact: An attacker positioned on the network path could intercept API credentials and impersonate the user or tamper with the returned audio content via MitM attacks.
Fix: Updated the endpoint URLs in `awesome_tts/awesometts/service/baidu.py` to use HTTPS instead of HTTP.
Verification: Code was verified manually and tested using `make check-py`, `make check-node`, and `make lint-fix` to ensure no functionality regressions.

---
*PR created automatically by Jules for task [16178703281994739772](https://jules.google.com/task/16178703281994739772) started by @ryusoh*