### PR TITLE
⚡ Bolt: Optimize render loops by hoisting static Canvas state

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -202,3 +202,7 @@
 
 **Learning:** Calling `getBoundingClientRect()` synchronously on every `mousemove` event inside interactive effects (like `tableGlassEffect`) forces the browser to recalculate layout continuously, causing layout thrashing and main thread blocking.
 **Action:** Pre-calculate and cache the bounding rectangle on `mouseenter` (adding `window.scrollX/scrollY` to handle scrolling) and reuse those cached dimensions with `e.pageX/pageY` inside `mousemove`. Invalidate the cache on `mouseleave` or `resize`.
+
+## 2024-05-31 - [Hoisting Canvas state properties outside Render Loop]
+**Learning:** Re-assigning native static property strings like `ctx.fillStyle` and `ctx.shadowColor` to the same color values inside rapid `requestAnimationFrame` inner `for` loops places completely unnecessary overhead on string parsing and state mutations by the browser on every 60fps frame tick.
+**Action:** Always extract invariant and static canvas state assignments (like `ctx.fillStyle`, `ctx.shadowColor`, and `ctx.shadowBlur = static`) out of rendering arrays/loops to significantly decrease paint times.

--- a/js/ui/tableGlassEffect.js
+++ b/js/ui/tableGlassEffect.js
@@ -626,9 +626,10 @@ export class TableGlassEffect {
         this.state.continuousPhase * (electric.streakSpeedMultiplier || 1);
       const headProgress = offset % 1;
 
-      // Subtle shadow
+      // Bolt: Hoist static canvas state assignments out of the inner render loop
       this.ctx.shadowColor = color;
       this.ctx.shadowBlur = 5;
+      this.ctx.strokeStyle = color;
 
       // Draw trail as segments
       for (let j = 0; j < segments; j++) {
@@ -643,13 +644,7 @@ export class TableGlassEffect {
         // Use a power curve for more elegant falloff
         const opacity = Math.pow(1 - segmentProgress, 2);
 
-        // Parse color to apply opacity
-        // Assuming color is rgba or hex, but for simplicity let's rely on globalAlpha
-        // and the fact that the palette colors might already have alpha.
-        // Best to use the base color and apply alpha.
-
         this.ctx.globalAlpha = opacity;
-        this.ctx.strokeStyle = color;
 
         this.ctx.beginPath();
         this.ctx.moveTo(point1.x, point1.y);
@@ -673,6 +668,11 @@ export class TableGlassEffect {
 
     this._pParticle = this._pParticle || { x: 0, y: 0 };
     const particles = this.state.energyParticles;
+
+    // Bolt: Hoist static canvas state assignments out of the inner render loop
+    this.ctx.fillStyle = electric.colors?.primary || "rgba(255, 255, 255, 0.8)";
+    this.ctx.shadowColor = this.ctx.fillStyle;
+
     for (let i = 0; i < particles.length; i++) {
       const p = particles[i];
       // Only draw path particles (those without 'life' property)
@@ -686,9 +686,6 @@ export class TableGlassEffect {
       const flicker =
         0.5 + 0.5 * Math.sin(this.state.phase * 10 + p.flickerOffset);
 
-      this.ctx.fillStyle =
-        electric.colors?.primary || "rgba(255, 255, 255, 0.8)";
-      this.ctx.shadowColor = this.ctx.fillStyle;
       this.ctx.shadowBlur = 3 * flicker; // Reduced blur
 
       this.ctx.beginPath();


### PR DESCRIPTION
💡 What: Hoisted static canvas state assignments (like `ctx.fillStyle`, `ctx.shadowColor`, and `ctx.strokeStyle`) outside the inner `for` loops in the `drawParticles` and `drawElectricTrails` methods of `js/ui/tableGlassEffect.js`.
🎯 Why: Re-assigning native static property strings inside high-frequency execution loops (like 60fps `requestAnimationFrame`) forces the browser to unnecessarily parse color strings and reapply identical state mutations on every iteration, which unnecessarily wastes CPU and risks frame drops.
📊 Impact: Decreases main-thread execution time for `draw()` on large datasets by reducing redundant browser API state mutations inside `for` loops.
🔬 Measurement: Can be verified by recording a Chrome Performance Profile over the Glass Table effect during continuous render ticks; standard CPU execution time associated with string resolution within Canvas context calls will be measurably reduced.

---
*PR created automatically by Jules for task [18037813176406943913](https://jules.google.com/task/18037813176406943913) started by @ryusoh*