### PR TITLE
Bolt: Optimize gsap usage in graph magnetic thumb

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -207,3 +207,8 @@
 
 **Learning:** Re-assigning native static property strings like `ctx.fillStyle` and `ctx.shadowColor` to the same color values inside rapid `requestAnimationFrame` inner `for` loops places completely unnecessary overhead on string parsing and state mutations by the browser on every 60fps frame tick.
 **Action:** Always extract invariant and static canvas state assignments (like `ctx.fillStyle`, `ctx.shadowColor`, and `ctx.shadowBlur = static`) out of rendering arrays/loops to significantly decrease paint times.
+
+## 2025-05-28 - [Optimize gsap in high-frequency events]
+
+**Learning:** Using `window.gsap.to()` repeatedly inside high-frequency event listeners like `mousemove` instantiates a new tween on every event, leading to significant GC (Garbage Collection) pressure and potential animation jitter.
+**Action:** Always pre-allocate `window.gsap.quickTo()` functions outside the event listener and invoke them with updated values to reuse the internal GSAP mechanism efficiently.

--- a/js/graph/graph.js
+++ b/js/graph/graph.js
@@ -757,6 +757,16 @@ if (window.gsap) {
     let centerX = 0;
     let centerY = 0;
 
+    // Bolt: Pre-allocate gsap quickTo functions to avoid creating new Tweens on every mousemove
+    const xTo = window.gsap.quickTo(magThumb, "x", {
+      duration: 0.3,
+      ease: "power2.out",
+    });
+    const yTo = window.gsap.quickTo(magThumb, "y", {
+      duration: 0.3,
+      ease: "power2.out",
+    });
+
     sliderGroup.addEventListener("mouseenter", () => {
       // Bolt: Cache bounding box dimensions to prevent layout thrashing inside
       // the high-frequency mousemove listener. Subtract current GSAP x/y transform
@@ -780,12 +790,8 @@ if (window.gsap) {
       const distX = e.pageX - centerX;
       const distY = e.pageY - centerY;
 
-      window.gsap.to(magThumb, {
-        x: distX * 0.15,
-        y: distY * 0.15,
-        duration: 0.3,
-        ease: "power2.out",
-      });
+      xTo(distX * 0.15);
+      yTo(distY * 0.15);
     });
 
     sliderGroup.addEventListener("mouseleave", () => {


### PR DESCRIPTION
⚡ Bolt: Optimize gsap in high-frequency events

💡 What: Refactored `window.gsap.to()` into pre-allocated `window.gsap.quickTo()` inside the `mousemove` event listener in `js/graph/graph.js`.
🎯 Why: Calling `window.gsap.to()` on every rapid event re-instantiates a new Tween, placing completely unnecessary overhead on the JavaScript engine and creating severe Garbage Collection (GC) pressure that can drop frames and cause jitter. 
📊 Impact: Eliminates object creation on `mousemove`, keeping the animation logic clean and reducing execution overhead to virtually zero.
🔬 Measurement: No behavior change. You can verify memory allocation drops in Chrome DevTools by observing the heap allocations during mouse movements over the `magnetic-thumb`.

---
*PR created automatically by Jules for task [474734191965294112](https://jules.google.com/task/474734191965294112) started by @ryusoh*