### PR TITLE
Bolt: Optimize getBoundingClientRect in sketch.js mouse events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -212,3 +212,8 @@
 
 **Learning:** Using `window.gsap.to()` repeatedly inside high-frequency event listeners like `mousemove` instantiates a new tween on every event, leading to significant GC (Garbage Collection) pressure and potential animation jitter.
 **Action:** Always pre-allocate `window.gsap.quickTo()` functions outside the event listener and invoke them with updated values to reuse the internal GSAP mechanism efficiently.
+
+## 2024-05-31 - Cache getBoundingClientRect on resize in sketch.js
+
+**Learning:** Calling `getBoundingClientRect()` synchronously on every mousemove event inside `sketch.js` forces the browser to recalculate layout continuously, causing layout thrashing and main thread blocking.
+**Action:** Pre-calculate and cache the bounding rectangle offset (including scroll) on `resize()` and reuse those cached dimensions inside `align()` for pointer event processing.

--- a/js/ambient/sketch.js
+++ b/js/ambient/sketch.js
@@ -209,11 +209,20 @@
       if (setup) {
         trigger(context.resize);
       }
+      // Bolt: Pre-calculate absolute document offsets during layout initialization/resize
+      // rather than synchronously querying getBoundingClientRect on every pointer event.
+      // This prevents severe layout thrashing and main-thread blocking during continuous
+      // animations or fast mouse movements.
+      if (context.element) {
+        bounds = context.element.getBoundingClientRect();
+        context._offsetX = bounds.left + (win.scrollX || win.pageXOffset);
+        context._offsetY = bounds.top + (win.scrollY || win.pageYOffset);
+      }
     }
     function align(t, tgt) {
-      bounds = tgt.getBoundingClientRect();
-      t.x = t.pageX - bounds.left - (win.scrollX || win.pageXOffset);
-      t.y = t.pageY - bounds.top - (win.scrollY || win.pageYOffset);
+      // Bolt: Read from cached offset properties to ensure O(1) continuous execution overhead.
+      t.x = t.pageX - (context._offsetX || 0);
+      t.y = t.pageY - (context._offsetY || 0);
       return t;
     }
     function augment(t, tgt) {


### PR DESCRIPTION
This PR optimizes the `align()` function in `js/ambient/sketch.js` which was synchronously calling `getBoundingClientRect()` on every `mousemove` or `touchmove` event. By moving this offset calculation to the `resize` handler and caching the value, we prevent severe layout thrashing and main-thread blocking during high-frequency pointer interactions.

---
*PR created automatically by Jules for task [16665561519803476573](https://jules.google.com/task/16665561519803476573) started by @ryusoh*