### PR TITLE
Palette: Add placeholder guidance to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -85,3 +85,8 @@
 
 **Learning:** Native `<input type="range">`, especially when styled with `outline: none`, becomes invisible to keyboard users as they navigate through the UI, breaking accessibility.
 **Action:** Always ensure that range inputs have an explicit `:focus-visible` style defined (e.g., `outline: 2px solid rgba(255, 255, 255, 0.8)`) so keyboard focus remains perceptible to the user.
+
+## 2026-06-01 - Terminal Input Placeholder Guidance
+
+**Learning:** Command-line interfaces embedded in web apps often lack visual cues for new users. Without a placeholder, users may not realize what interactions are possible or what commands are supported, leading to confusion.
+**Action:** Always provide a `placeholder` attribute on terminal or command-line input fields with a suggestive hint (e.g., "Type 'help' for commands...") to improve discoverability and provide helpful guidance without relying solely on external documentation.

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -193,6 +193,7 @@
               class="terminal-input"
               autocomplete="off"
               spellcheck="false"
+              placeholder="Type 'help' for commands..."
               aria-label="Terminal command input"
               autofocus
             />


### PR DESCRIPTION
Added a placeholder attribute (`placeholder="Type 'help' for commands..."`) to the terminal input in `terminal/index.html` to provide helpful guidance and improve discoverability for new users interacting with the embedded CLI. A learning entry regarding this was also added to `.jules/palette.md`.

---
*PR created automatically by Jules for task [1194331786164787665](https://jules.google.com/task/1194331786164787665) started by @ryusoh*