### PR TITLE
Palette: Add placeholder hint to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -85,3 +85,8 @@
 
 **Learning:** Native `<input type="range">`, especially when styled with `outline: none`, becomes invisible to keyboard users as they navigate through the UI, breaking accessibility.
 **Action:** Always ensure that range inputs have an explicit `:focus-visible` style defined (e.g., `outline: 2px solid rgba(255, 255, 255, 0.8)`) so keyboard focus remains perceptible to the user.
+
+## 2024-06-25 - Terminal Input Discoverability
+
+**Learning:** Terminal emulators often lack discoverability for new users who may not know which commands are available or how to interact with the interface.
+**Action:** Always include a `placeholder` attribute with a suggestive hint (like "Type 'help' for commands...") on terminal input fields to immediately guide users on how to begin.

--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -115,5 +115,6 @@
 **Learning:** Mocking module executions directly via `runpy.run_module(..., run_name="__main__")` properly checks if `main()` was invoked from `if __name__ == '__main__':` while isolating variables and tracking statement coverage appropriately. Used `unittest.mock.patch('sys.exit')` to avoid terminating test runners during execution.
 
 ## 2026-05-31 - Graph Analysis Output Tests
+
 **Learning:** When testing formatting and output functions that use `print` (such as `compare_decks` and `print_hub_notes`), use pytest's `capsys` fixture to capture `stdout` and assert on substring presence rather than exact string matching. This prevents brittle tests that fail on minor whitespace or truncation logic changes.
 **Action:** Use `capsys.readouterr().out` and `assert 'substring' in out` for CLI output tests.

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -194,6 +194,7 @@
               autocomplete="off"
               spellcheck="false"
               aria-label="Terminal command input"
+              placeholder="Type 'help' for commands..."
               autofocus
             />
           </div>


### PR DESCRIPTION
Adds a placeholder text to the terminal input field to improve discoverability for new users, guiding them to type 'help' for available commands. Also adds a journal entry to `.jules/palette.md` to document this learning.

---
*PR created automatically by Jules for task [1622174964747487322](https://jules.google.com/task/1622174964747487322) started by @ryusoh*