### PR TITLE
Bolt: Cache getBoundingClientRect on pointerenter in quantum_shader.js

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -217,3 +217,8 @@
 
 **Learning:** Calling `getBoundingClientRect()` synchronously on every mousemove event inside `sketch.js` forces the browser to recalculate layout continuously, causing layout thrashing and main thread blocking.
 **Action:** Pre-calculate and cache the bounding rectangle offset (including scroll) on `resize()` and reuse those cached dimensions inside `align()` for pointer event processing.
+
+## 2026-06-02 - [Optimize getBoundingClientRect in pointermove]
+
+**Learning:** Calling `getBoundingClientRect()` synchronously on every `pointermove` event inside high-frequency interactive animations (like `quantum_shader.js`) forces the browser to recalculate layout continuously, causing layout thrashing, severe frame drops, and main thread blocking.
+**Action:** Pre-calculate and cache the bounding rectangle on `pointerenter` (incorporating `window.scrollX/scrollY` offsets) and reuse those cached dimensions with `event.pageX/pageY` inside `pointermove`. Invalidate the cache on `pointerleave` or `resize`.

--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -115,5 +115,6 @@
 **Learning:** Mocking module executions directly via `runpy.run_module(..., run_name="__main__")` properly checks if `main()` was invoked from `if __name__ == '__main__':` while isolating variables and tracking statement coverage appropriately. Used `unittest.mock.patch('sys.exit')` to avoid terminating test runners during execution.
 
 ## 2026-05-31 - Graph Analysis Output Tests
+
 **Learning:** When testing formatting and output functions that use `print` (such as `compare_decks` and `print_hub_notes`), use pytest's `capsys` fixture to capture `stdout` and assert on substring presence rather than exact string matching. This prevents brittle tests that fail on minor whitespace or truncation logic changes.
 **Action:** Use `capsys.readouterr().out` and `assert 'substring' in out` for CLI output tests.

--- a/js/ambient/quantum_shader.js
+++ b/js/ambient/quantum_shader.js
@@ -78,10 +78,21 @@ function initControls(container, surface, state, uniforms, onStateChange) {
   let pointerId = null;
   let start = { x: 0, y: 0, nx: state.nx, ny: state.ny };
 
-  const updatePointerUniform = (x, y) => {
-    const rect = surface.getBoundingClientRect();
-    const px = clamp((x - rect.left) / rect.width, 0, 1);
-    const py = clamp((y - rect.top) / rect.height, 0, 1);
+  let cachedRect = null;
+
+  const updatePointerUniform = (pageX, pageY) => {
+    let rect = cachedRect;
+    if (!rect) {
+      const r = surface.getBoundingClientRect();
+      rect = {
+        left: r.left + window.scrollX,
+        top: r.top + window.scrollY,
+        width: r.width,
+        height: r.height,
+      };
+    }
+    const px = clamp((pageX - rect.left) / rect.width, 0, 1);
+    const py = clamp((pageY - rect.top) / rect.height, 0, 1);
     uniforms.pointerTarget.value.set(px, 1 - py);
   };
 
@@ -89,8 +100,8 @@ function initControls(container, surface, state, uniforms, onStateChange) {
     pointerActive = true;
     pointerId = event.pointerId;
     start = {
-      x: event.clientX,
-      y: event.clientY,
+      x: event.pageX,
+      y: event.pageY,
       nx: state.nx,
       ny: state.ny,
     };
@@ -103,21 +114,21 @@ function initControls(container, surface, state, uniforms, onStateChange) {
         // Ignore pointer capture failures on platforms that disallow it.
       }
     }
-    updatePointerUniform(event.clientX, event.clientY);
+    updatePointerUniform(event.pageX, event.pageY);
     container.classList.add("is-dragging");
   };
 
   const onPointerMove = (event) => {
     if (!pointerActive) {
-      updatePointerUniform(event.clientX, event.clientY);
+      updatePointerUniform(event.pageX, event.pageY);
       return;
     }
     if (pointerId !== event.pointerId) {
       return;
     }
 
-    const deltaX = (event.clientX - start.x) / 60;
-    const deltaY = (event.clientY - start.y) / 60;
+    const deltaX = (event.pageX - start.x) / 60;
+    const deltaY = (event.pageY - start.y) / 60;
     const newNx = clamp(Math.round(start.nx + deltaX), 0, MAX_N);
     const newNy = clamp(Math.round(start.ny - deltaY), 0, MAX_N);
 
@@ -132,7 +143,7 @@ function initControls(container, surface, state, uniforms, onStateChange) {
       onStateChange();
     }
 
-    updatePointerUniform(event.clientX, event.clientY);
+    updatePointerUniform(event.pageX, event.pageY);
   };
 
   const releasePointer = (event) => {
@@ -157,11 +168,22 @@ function initControls(container, surface, state, uniforms, onStateChange) {
     container.classList.remove("is-dragging");
   };
 
+  surface.addEventListener("pointerenter", () => {
+    const r = surface.getBoundingClientRect();
+    cachedRect = {
+      left: r.left + window.scrollX,
+      top: r.top + window.scrollY,
+      width: r.width,
+      height: r.height,
+    };
+  });
+
   surface.addEventListener("pointerdown", onPointerDown);
   surface.addEventListener("pointermove", onPointerMove);
   surface.addEventListener("pointerup", releasePointer);
   surface.addEventListener("pointercancel", releasePointer);
   surface.addEventListener("pointerleave", () => {
+    cachedRect = null;
     if (!pointerActive) {
       uniforms.pointerTarget.value.set(0.5, 0.5);
     }
@@ -585,6 +607,7 @@ function init() {
       requestAnimationFrame(render);
 
       const resize = () => {
+        cachedRect = null;
         const width = window.innerWidth;
         const height = window.innerHeight;
         backgroundRenderer.setSize(width, height, false);


### PR DESCRIPTION
💡 What: Pre-calculate and cache the bounding rectangle of the `surface` element on `pointerenter` (incorporating scroll offsets) in `js/ambient/quantum_shader.js` and reuse it with `event.pageX`/`pageY` inside `pointermove`. The cache is invalidated on `pointerleave` and `resize`.
🎯 Why: Calling `getBoundingClientRect()` synchronously on every `pointermove` event causes layout thrashing and main thread blocking, severely degrading the framerate of interactive animations.
📊 Impact: Eliminates synchronous layout recalculations during continuous pointer movement over the quantum shader canvas, significantly reducing UI jank.
🔬 Measurement: Verify by interacting with the quantum shader element and profiling main-thread activity in the browser DevTools (layout shift/recalculations should drop to near zero during interaction).

---
*PR created automatically by Jules for task [4443982085635922888](https://jules.google.com/task/4443982085635922888) started by @ryusoh*