### PR TITLE
Add unit tests for graph analysis functions

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -118,3 +118,7 @@
 
 **Learning:** When testing formatting and output functions that use `print` (such as `compare_decks` and `print_hub_notes`), use pytest's `capsys` fixture to capture `stdout` and assert on substring presence rather than exact string matching. This prevents brittle tests that fail on minor whitespace or truncation logic changes.
 **Action:** Use `capsys.readouterr().out` and `assert 'substring' in out` for CLI output tests.
+## 2024-05-31 - Generating Test Coverage Reports for Python
+
+**Learning:** To correctly generate Python test coverage reports for specific modules (e.g., `graph`) using `pytest-cov`, the root directory must be properly added to the Python path.
+**Action:** Use `PYTHONPATH=. python3 -m pytest --cov=<module_name> --cov-report=term-missing` directly from the repository root to ensure correct path resolution and accurate coverage metrics.

--- a/graph/tests/test_analyze.py
+++ b/graph/tests/test_analyze.py
@@ -335,6 +335,45 @@ class TestPrintIsolatedNotes:
         # Should show isolated nodes
         assert 'Isolated' in captured.out or 'isolated' in captured.out
 
+    def test_print_isolated_notes_empty(self, capsys):
+        from graph.analyze import print_isolated_notes
+        G = nx.DiGraph()
+        print_isolated_notes(G, "Test Deck")
+        assert "No isolated notes" in capsys.readouterr().out
+
+    def test_print_isolated_notes_truncation(self, capsys):
+        from graph.analyze import print_isolated_notes
+        G = nx.DiGraph()
+        for i in range(25):
+            G.add_node(f"node_{i}", front=f"Node {i}")
+        print_isolated_notes(G, "Test Deck")
+        out = capsys.readouterr().out
+        assert "Isolated Notes in Test Deck" in out
+        assert "and 5 more" in out
+
+
+class TestPrintHubNotes:
+    """Test print_hub_notes function."""
+
+    def test_print_hub_notes_empty(self, capsys):
+        from graph.analyze import print_hub_notes
+        G = nx.DiGraph()
+        print_hub_notes(G, "Test Deck")
+        assert "No hub notes found" in capsys.readouterr().out
+
+    def test_print_hub_notes_truncation(self, capsys):
+        from graph.analyze import print_hub_notes
+        G = nx.DiGraph()
+        G.add_node("n1", front="A" * 40, pagerank=0.5)
+        G.add_node("n2", front="B" * 40, pagerank=0.1)
+        G.add_edge("n1", "n2")
+        G.add_edge("n2", "n1")
+        print_hub_notes(G, "Test Deck")
+        out = capsys.readouterr().out
+        assert "Hub Notes in Test Deck" in out
+        assert "AAAAAAAAAAAAAAAAAAAAAAAAAAAA.." in out
+        assert "BBBBBBBBBBBBBBBBBBBBBBBBBBBB.." in out
+
 
 class TestExportGraph:
     """Test export_graph function."""


### PR DESCRIPTION
Adds coverage for missing cases in graph/analyze.py for isolated and hub nodes, specifically focusing on handling empty state and testing string truncation paths.

---
*PR created automatically by Jules for task [9647875419436294468](https://jules.google.com/task/9647875419436294468) started by @ryusoh*