### PR TITLE
🎨 Palette: Add placeholder to terminal input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -85,3 +85,8 @@
 
 **Learning:** Native `<input type="range">`, especially when styled with `outline: none`, becomes invisible to keyboard users as they navigate through the UI, breaking accessibility.
 **Action:** Always ensure that range inputs have an explicit `:focus-visible` style defined (e.g., `outline: 2px solid rgba(255, 255, 255, 0.8)`) so keyboard focus remains perceptible to the user.
+
+## 2024-05-24 - Add Terminal Placeholder
+
+**Learning:** Command-line interfaces can be unintuitive for new users if there's no hint of what to type. A placeholder provides immediate discoverability without cluttering the UI.
+**Action:** Always include a suggestive placeholder like "Type 'help' for commands..." in terminal or command-line style input fields.

--- a/terminal/index.html
+++ b/terminal/index.html
@@ -194,6 +194,7 @@
               autocomplete="off"
               spellcheck="false"
               aria-label="Terminal command input"
+              placeholder="Type 'help' for commands..."
               autofocus
             />
           </div>


### PR DESCRIPTION
**💡 What:** Added a `placeholder` attribute to the `#terminalInput` element in `terminal/index.html`.
**🎯 Why:** Command-line interfaces can be intimidating or unintuitive for users unfamiliar with them. A suggestive placeholder provides immediate, non-intrusive guidance on how to start interacting with the terminal.
**📸 Before/After:** N/A (Visual change verified via Playwright)
**♿ Accessibility:** Improves cognitive accessibility by providing immediate instructions and lowering the barrier to entry for interacting with the custom terminal component.

---
*PR created automatically by Jules for task [15820452868345752256](https://jules.google.com/task/15820452868345752256) started by @ryusoh*