### PR TITLE
Bolt: Optimize getBoundingClientRect in GSAP Ticker

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -227,3 +227,8 @@
 
 **Learning:** Instantiating new `CanvasGradient` objects via `createLinearGradient()` inside high-frequency animation loops (like `requestAnimationFrame`) creates heavy garbage collection (GC) overhead. If the gradient moves dynamically (e.g., during a sweep effect driven by a phase value), caching it at static coordinates doesn't work.
 **Action:** Create and cache the gradient object centered at `(0, 0)` during initialization or resize. Inside the render loop, use `ctx.translate()` to move the canvas context to the dynamic target coordinates, fill the shape using the cached gradient relative to the translated origin, and then call `ctx.restore()`. This completely eliminates gradient object allocation overhead on every frame.
+
+## 2025-06-03 - [Optimize getBoundingClientRect in GSAP Ticker]
+
+**Learning:** Calling `getBoundingClientRect()` inside a high-frequency `gsap.ticker` animation loop to get a static element's dimensions causes severe layout thrashing and blocks the main thread. Caching relative dimensions alone is unsafe if the page layout shifts dynamically.
+**Action:** To prevent layout thrashing inside high-frequency animation loops (e.g., `gsap.ticker`), avoid querying `getBoundingClientRect()` for elements whose position isn't continuously changing. Hoist the calculation outside the loop, cache the absolute document coordinates (adding `window.scrollX/scrollY`), and use a `ResizeObserver` on `document.body` to invalidate and recalculate the layout cache when layout shifts occur. Inside the loop, subtract the fast-to-read `window.scrollX/scrollY` to calculate relative viewport coordinates.

--- a/js/ui/marquee.js
+++ b/js/ui/marquee.js
@@ -106,6 +106,32 @@ function initGravitationalDistortion(widget, charGroups) {
   // Bolt: Pre-calculate static character positions relative to their parent container
   // to avoid calling O(N) getBoundingClientRect() inside the gsap.ticker animation loop,
   // which causes severe layout thrashing and main-thread blocking.
+  // Bolt: Hoist widget layout dimensions outside the ticker to prevent continuous
+  // main thread layout thrashing on every 60fps frame. We cache absolute document
+  // positions (adding scroll offsets) to correctly handle user scrolling.
+  let wAbsoluteCx = 0;
+  let wAbsoluteCy = 0;
+  let widgetVisible = false;
+
+  const updateWidgetLayout = () => {
+    const wRect = widget.getBoundingClientRect();
+    widgetVisible = wRect.width > 0;
+    if (widgetVisible) {
+      wAbsoluteCx = wRect.left + window.scrollX + wRect.width / 2;
+      wAbsoluteCy = wRect.top + window.scrollY + wRect.height / 2;
+    }
+  };
+
+  updateWidgetLayout();
+
+  if (typeof window !== "undefined" && window.addEventListener) {
+    window.addEventListener("resize", updateWidgetLayout);
+    if (typeof window.ResizeObserver === "function") {
+      const resizeObserver = new window.ResizeObserver(updateWidgetLayout);
+      resizeObserver.observe(document.body);
+    }
+  }
+
   charGroups.forEach((group) => {
     if (group.spans.length === 0) return;
 
@@ -127,12 +153,14 @@ function initGravitationalDistortion(widget, charGroups) {
   });
 
   window.gsap.ticker.add(() => {
-    const wRect = widget.getBoundingClientRect();
-    if (wRect.width === 0) {
+    if (!widgetVisible) {
       return;
     }
-    const wcx = wRect.left + wRect.width / 2;
-    const wcy = wRect.top + wRect.height / 2;
+
+    // Convert cached absolute center back to viewport-relative
+    // Reading scrollY doesn't cause layout thrashing
+    const wcx = wAbsoluteCx - window.scrollX;
+    const wcy = wAbsoluteCy - window.scrollY;
 
     for (const {
       spans,


### PR DESCRIPTION
💡 What: Hoisted `getBoundingClientRect` layout queries for the static `widget` element out of the high-frequency `gsap.ticker` animation loop in `marquee.js`. The script now caches absolute document positions and registers a `ResizeObserver` on `document.body` to intelligently invalidate and update the cache upon layout shifts. Inside the render loop, fast native viewport properties (`window.scrollX` / `window.scrollY`) are used to compute required relative translations.
🎯 Why: Calling `getBoundingClientRect()` synchronously on every 60fps frame causes severe layout thrashing (forced synchronous layout), constantly blocking the main thread and severely dropping animation framerates.
📊 Impact: Completely eliminates layout thrashing during the marquee animation, restoring smooth 60fps animation performance without locking the main thread.
🔬 Measurement: Verify via Chrome DevTools Performance Profiler that `Recalculate Style` and `Layout` events are no longer continuously triggered during the marquee animation frame.

---
*PR created automatically by Jules for task [15452582720310304084](https://jules.google.com/task/15452582720310304084) started by @ryusoh*