### PR TITLE
⚡ Bolt: Optimize canvas rendering in ambient background

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -232,3 +232,8 @@
 
 **Learning:** Calling `getBoundingClientRect()` inside a high-frequency `gsap.ticker` animation loop to get a static element's dimensions causes severe layout thrashing and blocks the main thread. Caching relative dimensions alone is unsafe if the page layout shifts dynamically.
 **Action:** To prevent layout thrashing inside high-frequency animation loops (e.g., `gsap.ticker`), avoid querying `getBoundingClientRect()` for elements whose position isn't continuously changing. Hoist the calculation outside the loop, cache the absolute document coordinates (adding `window.scrollX/scrollY`), and use a `ResizeObserver` on `document.body` to invalidate and recalculate the layout cache when layout shifts occur. Inside the loop, subtract the fast-to-read `window.scrollX/scrollY` to calculate relative viewport coordinates.
+
+## 2026-06-05 - [Optimize canvas globalAlpha vs string interpolation in render loops]
+
+**Learning:** Constructing rgba strings like `'rgba(255, 255, 255, ' + alpha + ')'` inside high-frequency execution loops, such as `requestAnimationFrame` render layers, creates severe GC overhead from string instantiation and requires the browser to parse the string on every single frame.
+**Action:** Hoist the static `ctx.fillStyle` or `ctx.strokeStyle` color string parsing outside of the loop. Inside the loop, mutate the canvas context's `globalAlpha` property directly instead of recreating color strings, resulting in zero allocation and much faster render times.

--- a/js/ambient/ambient.js
+++ b/js/ambient/ambient.js
@@ -138,11 +138,14 @@
         ctx.fillStyle = "rgba(0,128,255,0.12)";
         ctx.fillRect(0, 0, this.width, this.height);
       }
+      // Bolt: Hoist static canvas state assignment outside the render loop
+      ctx.fillStyle = "#ffffff";
       for (let i = 0; i < particles.length; i++) {
         const p = particles[i];
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2, false);
-        ctx.fillStyle = "rgba(255,255,255," + p.a + ")";
+        // Bolt: Use globalAlpha instead of concatenating strings to reduce GC pressure
+        ctx.globalAlpha = p.a;
         ctx.fill();
       }
       ctx.restore();


### PR DESCRIPTION
⚡ Bolt: Optimize canvas rendering in ambient background

This PR targets `js/ambient/ambient.js` to implement a critical Canvas rendering optimization.

💡 **What:** Replaced the string concatenation of `ctx.fillStyle` (`"rgba(255,255,255," + p.a + ")"`) inside the `s.draw` particles loop with a hoisted static color assignment (`ctx.fillStyle = "#ffffff"`) and a dynamic `ctx.globalAlpha = p.a` mutation.
🎯 **Why:** Constructing dynamic color strings inside a high-frequency (60fps) `requestAnimationFrame` loop causes severe Garbage Collection (GC) overhead and forces the browser to re-parse the color string up to 120 times per frame.
📊 **Impact:** Reduces GC pressure significantly and speeds up particle drawing execution time by removing runtime string allocations.
🔬 **Measurement:** Use Chrome DevTools Performance Profiler. Inspect the "Minor GC" frequency and CPU time spent in `ambient.js:s.draw()` before and after the change.

Tested via `make check-node`.

---
*PR created automatically by Jules for task [5568035038537984834](https://jules.google.com/task/5568035038537984834) started by @ryusoh*