### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix innerHTML XSS risk in Review Heatmap

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -182,3 +182,9 @@ element.innerHTML = `<p>${error.message}</p>`;
 **Vulnerability:** Unencrypted data transmission (HTTP) was used for Baidu API endpoints (`http://openapi.baidu.com` and `http://tsn.baidu.com`), risking MitM exposure of API credentials, OAuth tokens, and audio data.
 **Learning:** Using HTTP for external APIs, even non-critical ones, exposes sensitive request headers and payload data to interception and tampering, failing defense-in-depth principles.
 **Prevention:** Always enforce HTTPS for any external API requests, especially those exchanging authentication tokens or processing user data.
+
+## 2024-05-24 - Prevent DOM-based XSS by removing innerHTML in Review Heatmap script injections
+
+**Vulnerability:** In `review_heatmap/views.py`, the dynamic javascript block injected into the application was using `template.innerHTML = heatmapHtml`, `style.innerHTML = ...`, and `container.innerHTML = ""` to render and clear elements.
+**Learning:** Assigning dynamically built strings to `innerHTML` violates modern SAST rules and risks accidental XSS introduction during future modifications, even if the variables are thought to be safe. Safe DOM APIs should be the standard everywhere.
+**Prevention:** Always use safe DOM manipulation methods like `DOMParser().parseFromString()` for HTML parsing, `element.textContent` for plain text/CSS, and `element.textContent = ""` or `element.replaceChildren()` to clear elements securely instead of `element.innerHTML`.

--- a/review_heatmap/views.py
+++ b/review_heatmap/views.py
@@ -226,7 +226,7 @@ class OverviewInjector(HeatmapInjector):
         }
         const style = document.createElement("style");
         style.id = inlineStyleId;
-        style.innerHTML = `
+        style.textContent = `
             #${containerId} {
                 width: 100%;
                 display: flex;
@@ -285,9 +285,17 @@ class OverviewInjector(HeatmapInjector):
     };
 
     const parseMarkup = () => {
-        const template = document.createElement("template");
-        template.innerHTML = heatmapHtml;
-        const fragment = template.content;
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(heatmapHtml, "text/html");
+        const fragment = document.createDocumentFragment();
+        // Move all nodes from body into fragment
+        while (doc.body.firstChild) {
+            fragment.appendChild(doc.body.firstChild);
+        }
+        // Also move scripts/styles that might end up in head
+        while (doc.head.firstChild) {
+            fragment.appendChild(doc.head.firstChild);
+        }
         const scripts = [];
         fragment.querySelectorAll("script").forEach((script) => {
             scripts.push({
@@ -320,7 +328,7 @@ class OverviewInjector(HeatmapInjector):
             ensureScopedStyles();
 
             const { fragment, scripts, styles } = parseMarkup();
-            container.innerHTML = "";
+            container.textContent = "";
             container.style.opacity = "0";
             container.style.transition = "opacity 0.2s ease-in";
             container.appendChild(fragment);


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Dynamic Javascript string generation assigns raw HTML string to `.innerHTML` via `template.innerHTML = heatmapHtml;`, `style.innerHTML = ...`, and `container.innerHTML = "";`.
🎯 Impact: Accidental modification to `heatmapHtml` to include an unsanitized untrusted string would lead to XSS. Unsafe DOM practices violate SAST security standards.
🔧 Fix: Replaced `innerHTML` with `DOMParser().parseFromString()` for element construction and `.textContent` for style/clearing logic.
✅ Verification: `make check-node` and `make check-py` tests all passed after modification.

---
*PR created automatically by Jules for task [10078547715807274879](https://jules.google.com/task/10078547715807274879) started by @ryusoh*