### PR TITLE
⚡ Bolt: Optimize Canvas gradient object allocations in Glass Effect render loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -237,3 +237,8 @@
 
 **Learning:** Constructing rgba strings like `'rgba(255, 255, 255, ' + alpha + ')'` inside high-frequency execution loops, such as `requestAnimationFrame` render layers, creates severe GC overhead from string instantiation and requires the browser to parse the string on every single frame.
 **Action:** Hoist the static `ctx.fillStyle` or `ctx.strokeStyle` color string parsing outside of the loop. Inside the loop, mutate the canvas context's `globalAlpha` property directly instead of recreating color strings, resulting in zero allocation and much faster render times.
+
+## 2025-06-08 - [Optimize linear gradient allocations in Animated Glass Background render loops]
+
+**Learning:** Instantiating new \`CanvasGradient\` objects via \`createLinearGradient()\` inside high-frequency animation loops (like \`requestAnimationFrame\`) creates heavy garbage collection (GC) overhead. If the gradient moves dynamically (e.g., during a reflection effect driven by a phase value), caching it at static coordinates doesn't work.
+**Action:** Create and cache the gradient object centered at \`(0, 0)\` during initialization or resize. Inside the render loop, use \`ctx.translate()\` to move the canvas context to the dynamic target coordinates, fill the shape using the cached gradient relative to the translated origin, and then call \`ctx.restore()\`. This completely eliminates gradient object allocation overhead on every frame.

--- a/animated_glass_background/web/glass_effect.js
+++ b/animated_glass_background/web/glass_effect.js
@@ -181,6 +181,8 @@
       this.canvas.height = this.height * dpr;
       this.ctx.scale(dpr, dpr);
       this.cachedLayout = null; // Reset cache on resize
+      this._ambientGradientCache = null;
+      this._reflectionGradientCache = null;
 
       const isBottom =
         window.location.href.includes("bottom") ||
@@ -301,21 +303,27 @@
       this.drawPath(this.ctx, radius);
       this.ctx.clip();
 
-      const gradient = this.ctx.createLinearGradient(
-        0,
-        -layout.offsetY,
-        layout.totalWidth,
-        layout.totalHeight - layout.offsetY,
-      );
+      // Bolt: Cache Canvas gradients to eliminate heavy object allocations in the high-frequency render loop
+      if (!this._ambientGradientCache) {
+        this._ambientGradientCache = this.ctx.createLinearGradient(
+          0,
+          -layout.offsetY,
+          layout.totalWidth,
+          layout.totalHeight - layout.offsetY,
+        );
 
-      // Distribute the blue glow more evenly across the diagonal
-      const baseColor = glow.innerColor || "rgba(118, 183, 229, 0.5)";
-      gradient.addColorStop(0, baseColor);
-      gradient.addColorStop(0.6, "rgba(118, 183, 229, 0.25)");
-      gradient.addColorStop(1, "rgba(118, 183, 229, 0.05)");
+        // Distribute the blue glow more evenly across the diagonal
+        const baseColor = glow.innerColor || "rgba(118, 183, 229, 0.5)";
+        this._ambientGradientCache.addColorStop(0, baseColor);
+        this._ambientGradientCache.addColorStop(
+          0.6,
+          "rgba(118, 183, 229, 0.25)",
+        );
+        this._ambientGradientCache.addColorStop(1, "rgba(118, 183, 229, 0.05)");
+      }
 
       this.ctx.globalAlpha = (glow.innerOpacity || 0.8) * (0.8 + pulse * 0.2);
-      this.ctx.fillStyle = gradient;
+      this.ctx.fillStyle = this._ambientGradientCache;
       this.ctx.fill();
       this.ctx.restore();
     }
@@ -329,16 +337,7 @@
       this.ctx.save();
       this.ctx.globalCompositeOperation = "overlay";
 
-      const gradient = this.ctx.createLinearGradient(
-        0,
-        -layout.offsetY,
-        layout.totalWidth,
-        layout.totalHeight - layout.offsetY,
-      );
-
       const phase = this.state.phase;
-      const start = phase - width;
-      const end = phase + width;
 
       let fadeMultiplier = 1.0;
       if (phase > 1 - fadeZone) {
@@ -349,13 +348,30 @@
 
       this.ctx.globalAlpha = intensity * fadeMultiplier;
 
-      gradient.addColorStop(Math.max(0, start), "rgba(255,255,255,0)");
-      gradient.addColorStop(Math.max(0, Math.min(1, phase)), color);
-      gradient.addColorStop(Math.min(1, end), "rgba(255,255,255,0)");
-
-      this.ctx.fillStyle = gradient;
       this.drawPath(this.ctx, radius);
-      this.ctx.fill();
+      this.ctx.clip();
+
+      // Bolt: Cache Canvas gradients to eliminate heavy object allocations in the high-frequency render loop.
+      // For moving gradients, we create them centered at (0, 0) and use ctx.translate() to position them,
+      // avoiding the need to re-instantiate the gradient object on every frame.
+      if (!this._reflectionGradientCache) {
+        this._reflectionGradientCache = this.ctx.createLinearGradient(
+          -width * layout.totalWidth,
+          -width * layout.totalHeight,
+          width * layout.totalWidth,
+          width * layout.totalHeight,
+        );
+        this._reflectionGradientCache.addColorStop(0, "rgba(255,255,255,0)");
+        this._reflectionGradientCache.addColorStop(0.5, color);
+        this._reflectionGradientCache.addColorStop(1, "rgba(255,255,255,0)");
+      }
+
+      const centerX = phase * layout.totalWidth;
+      const centerY = phase * layout.totalHeight - layout.offsetY;
+
+      this.ctx.translate(centerX, centerY);
+      this.ctx.fillStyle = this._reflectionGradientCache;
+      this.ctx.fillRect(-centerX, -centerY, this.width, this.height);
 
       this.ctx.restore();
     }


### PR DESCRIPTION
💡 What: Cached `createLinearGradient` instances in `animated_glass_background/web/glass_effect.js` by tracking them on the class (`_ambientGradientCache` and `_reflectionGradientCache`) and using `ctx.translate` inside the high-frequency render loop (`requestAnimationFrame`) to handle positioning without recreating the canvas objects every single frame.

🎯 Why: Instantiating new Canvas gradient objects via `createLinearGradient()` and adding color stops on every animation frame produces severe garbage collection (GC) overhead and unneeded CPU burn. This causes micro-stutters and dropping framerates on devices running the animated glass background.

📊 Impact: Reduces GC allocations from gradients by 100% inside the `draw` call loop, dropping from roughly 120 gradient instantiations per second (at 60fps) to 0.

🔬 Measurement: Use Chrome DevTools Performance tab. Record a session with the background visible. You will see significantly fewer Memory allocations and `Minor GC` events for the `glass_effect.js` script, and faster frame execution times.

---
*PR created automatically by Jules for task [1143799370550781040](https://jules.google.com/task/1143799370550781040) started by @ryusoh*