### PR TITLE
⚡ Bolt: optimize getComputedStyle in tableGlassEffect resize

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -247,3 +247,8 @@
 
 **Learning:** Instantiating new arrays and running filter loops inside high-frequency animation loops (like `requestAnimationFrame`) based on static configuration values creates heavy garbage collection (GC) overhead and wastes CPU cycles.
 **Action:** Cache the processed arrays and length counts on the class instance lazily or during initialization. Reuse the cached properties inside the render loop to eliminate per-frame allocations.
+
+## 2025-06-09 - [Optimize redundant getComputedStyle calls in high-frequency methods]
+
+**Learning:** Calling `window.getComputedStyle()` forces a synchronous style recalculation in the browser, which is an expensive operation. Calling it multiple times on the same element within the same high-frequency function (like `resize` or an animation loop) is redundant and wastes CPU cycles, adding unnecessary overhead.
+**Action:** When multiple computed style properties are needed from the same element, call `getComputedStyle(element)` once, assign it to a local constant variable, and read the necessary properties from that cached object.

--- a/js/ui/tableGlassEffect.js
+++ b/js/ui/tableGlassEffect.js
@@ -157,9 +157,9 @@ export class TableGlassEffect {
     }
 
     // Re-evaluate whether content actually overflows and update positioning
-    const overflowStyle =
-      window.getComputedStyle(this.container).overflow +
-      window.getComputedStyle(this.container).overflowY;
+    // Bolt: Cache getComputedStyle to avoid redundant synchronous style recalculations
+    const containerStyle = window.getComputedStyle(this.container);
+    const overflowStyle = containerStyle.overflow + containerStyle.overflowY;
     const nowScrollable =
       /auto|scroll/.test(overflowStyle) &&
       this.container.scrollHeight > this.container.clientHeight + 1;


### PR DESCRIPTION
💡 What: Cached the result of `window.getComputedStyle(this.container)` into a local variable inside `tableGlassEffect.js`'s `resize()` method instead of calling it twice.
🎯 Why: `getComputedStyle` is an expensive synchronous operation that forces the browser to recalculate styles. Calling it repeatedly in rapid succession (like during a `ResizeObserver` callback) creates heavy main-thread blocking and layout thrashing.
📊 Impact: Cuts the `getComputedStyle` overhead in half for this code path, ensuring smoother resize transitions.
🔬 Measurement: Verify via Chrome DevTools Performance profile during rapid window resizing or table content changes.

---
*PR created automatically by Jules for task [1734464578947645686](https://jules.google.com/task/1734464578947645686) started by @ryusoh*