### PR TITLE
🛡️ Sentinel: Fix Security Audit Tool False Positives

### DIFF
--- a/tools/security_audit.py
+++ b/tools/security_audit.py
@@ -50,7 +50,12 @@ def check_for_credentials(filepath, content):
     issues = []
 
     # Skip vendor/third-party code (they have their own keys)
-    if 'vendor/' in filepath or 'node_modules/' in filepath or 'tests/' in filepath:
+    if (
+        'vendor/' in filepath
+        or 'node_modules/' in filepath
+        or 'tests/' in filepath
+        or 'test_' in filepath
+    ):
         return issues
 
     # Skip documentation


### PR DESCRIPTION
🛡️ Sentinel: Fix Security Audit Tool False Positives

The `tools/security_audit.py` script was flagging its own unit test file (`tools/test_security_audit.py`) as containing hardcoded secrets and private data. This is a false positive because the unit tests contain mock examples of the exact strings or structures the tool is designed to find.

This PR adds a check to ignore `test_` prefixed files in `tools/security_audit.py` to prevent these false positives, ensuring the audit accurately reflects the state of production code.

---
*PR created automatically by Jules for task [13114914747032672478](https://jules.google.com/task/13114914747032672478) started by @ryusoh*