### PR TITLE
test: improve coverage for graph analysis and stats customizer

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -162,3 +162,6 @@
 
 **Learning:** These small add-ons are entirely devoid of test coverage and often just append hooks or have one primary module entry point. Mocking `aqt` completely with a clean MagicMock enables standard tests to be performed on small one-off function hooks, specifically making sure they don't crash when `aqt` is absent, and the HTML/CSS edits output properly.
 **Action:** Created isolated minimal tests mocking `aqt` contexts (`DeckBrowser`, `OtherContext`) and setting `head="<html>"` to assert if CSS injections properly function, and verifying hook binding processes directly with simple data.
+## 2025-02-27 - Test coverage updates
+**Learning:** Pytest mocking of `Path` from `pathlib` involves mocking standard directory structures such as multiple `__truediv__` calls (`parent / "dir"` operations) correctly. When a single test function accesses `Path`, using `new_callable=MagicMock` or direct `@patch` works well to mock existence without attempting to evaluate attributes like `.exists` as read-only.
+**Learning:** For class method patching with decorators (like modifying `__init__`), mocking external attributes or deleting properties directly can cause errors. Testing fallbacks should emulate alternative structures such as explicitly testing for missing attributes using standard instances where expected variables are naturally absent.

--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -162,6 +162,8 @@
 
 **Learning:** These small add-ons are entirely devoid of test coverage and often just append hooks or have one primary module entry point. Mocking `aqt` completely with a clean MagicMock enables standard tests to be performed on small one-off function hooks, specifically making sure they don't crash when `aqt` is absent, and the HTML/CSS edits output properly.
 **Action:** Created isolated minimal tests mocking `aqt` contexts (`DeckBrowser`, `OtherContext`) and setting `head="<html>"` to assert if CSS injections properly function, and verifying hook binding processes directly with simple data.
+
 ## 2025-02-27 - Test coverage updates
+
 **Learning:** Pytest mocking of `Path` from `pathlib` involves mocking standard directory structures such as multiple `__truediv__` calls (`parent / "dir"` operations) correctly. When a single test function accesses `Path`, using `new_callable=MagicMock` or direct `@patch` works well to mock existence without attempting to evaluate attributes like `.exists` as read-only.
 **Learning:** For class method patching with decorators (like modifying `__init__`), mocking external attributes or deleting properties directly can cause errors. Testing fallbacks should emulate alternative structures such as explicitly testing for missing attributes using standard instances where expected variables are naturally absent.

--- a/graph/tests/test_analyze.py
+++ b/graph/tests/test_analyze.py
@@ -650,3 +650,67 @@ def test_analyze_all_decks(capsys):
         assert mock_print_isolated.call_count == 2
         assert mock_print_hub.call_count == 2
         assert mock_export.call_count == 2
+
+
+@patch('graph.analyze.Path')
+@patch('graph.analyze.load_notes_from_file')
+@patch('graph.analyze.build_deck_map_from_cards')
+def test_load_notes_with_decks_r2(mock_build, mock_load, mock_path):
+    mock_r2_staged = (
+        mock_path.return_value.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value
+    )
+    mock_r2_staged.exists.return_value = True
+    mock_load.return_value = [{'id': 1}]
+
+    from graph.analyze import load_notes_with_decks
+
+    notes = load_notes_with_decks()
+    assert notes == [{'id': 1}]
+
+
+@patch('graph.analyze.Path')
+@patch('graph.analyze.load_notes_from_file')
+@patch('graph.analyze.build_deck_map_from_cards')
+def test_load_notes_with_decks_github(mock_build, mock_load, mock_path):
+    # Mock R2 staging path does not exist
+    mock_r2_staged = (
+        mock_path.return_value.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value
+    )
+    mock_r2_staged.exists.return_value = False
+
+    # Mock GitHub fallback path exists
+    mock_github_data = (
+        mock_path.return_value.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value
+    )
+    mock_github_data.exists.return_value = True
+
+    mock_load.return_value = [{'id': 1}]
+    mock_build.return_value = {1: {'deck_name': 'Test Deck', 'did': 123}}
+
+    from graph.analyze import load_notes_with_decks
+
+    notes = load_notes_with_decks()
+    assert len(notes) == 1
+    assert notes[0]['id'] == 1
+    assert notes[0]['deck'] == 'Test Deck'
+    assert notes[0]['deck_id'] == 123
+
+
+@patch('graph.analyze.Path')
+def test_load_notes_with_decks_none(mock_path, capsys):
+    mock_r2_staged = (
+        mock_path.return_value.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value
+    )
+    mock_r2_staged.exists.return_value = False
+    mock_github_data = (
+        mock_path.return_value.parent.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value
+    )
+    mock_github_data.exists.return_value = False
+
+    from graph.analyze import load_notes_with_decks
+
+    notes = load_notes_with_decks()
+    assert notes == []
+
+    captured = capsys.readouterr()
+    assert "No notes found" in captured.err

--- a/stats_page_customizer/tests/test_stats_fetch.py
+++ b/stats_page_customizer/tests/test_stats_fetch.py
@@ -1,0 +1,41 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+_mock_aqt = MagicMock()
+
+
+class _FakeStatsClass:
+    def __init__(self, *a, **kw):
+        pass
+
+    def refresh(self, *a, **kw):
+        pass
+
+
+_mock_stats = MagicMock()
+_mock_stats.DeckStats = _FakeStatsClass
+_mock_stats.NewDeckStats = _FakeStatsClass
+
+sys.modules["aqt"] = _mock_aqt
+sys.modules["aqt.gui_hooks"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.stats"] = _mock_stats
+sys.modules["aqt.utils"] = MagicMock()
+sys.modules["aqt.webview"] = MagicMock()
+
+from stats_page_customizer import _fetch_future_due_rows, mw
+
+
+def test_fetch_future_due_rows():
+    mw.col.db.all.return_value = [(0, 5, 2)]
+    res = _fetch_future_due_rows(today=100, max_days=30)
+    assert res == [(0, 5, 2)]
+    mw.col.db.all.assert_called_once()
+
+
+def test_fetch_future_due_rows_none():
+    from stats_page_customizer import _fetch_future_due_rows, mw
+
+    mw.col.db.all.return_value = []
+    res = _fetch_future_due_rows(today=100, max_days=30)
+    assert res == []

--- a/stats_page_customizer/tests/test_stats_gather.py
+++ b/stats_page_customizer/tests/test_stats_gather.py
@@ -1,0 +1,97 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_mock_aqt = MagicMock()
+
+
+class _FakeStatsClass:
+    def __init__(self, *a, **kw):
+        pass
+
+    def refresh(self, *a, **kw):
+        pass
+
+
+_mock_stats = MagicMock()
+_mock_stats.DeckStats = _FakeStatsClass
+_mock_stats.NewDeckStats = _FakeStatsClass
+
+sys.modules["aqt"] = _mock_aqt
+sys.modules["aqt.gui_hooks"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.stats"] = _mock_stats
+sys.modules["aqt.utils"] = MagicMock()
+sys.modules["aqt.webview"] = MagicMock()
+
+from stats_page_customizer import _gather_future_due, mw
+
+
+@patch('stats_page_customizer._fetch_future_due_rows')
+def test_gather_future_due_success(mock_fetch):
+    mock_fetch.return_value = [(0, 5, 2), (1, 10, 0)]
+    mw.col.sched.today = 1000
+
+    res = _gather_future_due(days=3)
+
+    assert len(res) == 4
+    assert res[0]['mature'] == 5
+    assert res[0]['young'] == 2
+    assert res[1]['mature'] == 10
+
+
+@patch('stats_page_customizer._fetch_future_due_rows')
+def test_gather_future_due_exception(mock_fetch):
+    mock_fetch.side_effect = Exception("Test Exception")
+    mw.col.sched.today = 1000
+
+    with pytest.raises(Exception, match='Test Exception'):
+        _gather_future_due(days=3)
+
+
+def test_gather_future_due_no_mw():
+    old_mw = sys.modules['stats_page_customizer'].mw
+    sys.modules['stats_page_customizer'].mw = None
+    res = _gather_future_due()
+    assert res == []
+    sys.modules['stats_page_customizer'].mw = old_mw
+
+
+def test_gather_future_due_sched_exception():
+    old_col = mw.col
+    mw.col = MagicMock()
+    type(mw.col.sched).today = property(lambda self: (_ for _ in ()).throw(Exception("test")))
+
+    res = _gather_future_due()
+    assert res == []
+    mw.col = old_col
+
+
+def test_process_future_due_rows():
+    from stats_page_customizer import _process_future_due_rows
+
+    rows = [(0, 5, 2), (1, 10, 0), (5, 0, 3)]
+    res = _process_future_due_rows(rows, max_days=30)
+    assert len(res) == 31  # 0 to 30 inclusive
+    assert res[0]['day'] == 0
+    assert res[0]['mature'] == 5
+    assert res[0]['young'] == 2
+    assert res[1]['mature'] == 10
+    assert res[1]['young'] == 0
+    assert res[5]['mature'] == 0
+    assert res[5]['young'] == 3
+    assert res[2]['mature'] == 0
+    assert res[2]['young'] == 0
+
+
+def test_process_future_due_rows_out_of_bounds():
+    from stats_page_customizer import _process_future_due_rows
+
+    # Day -1 should be skipped, Day 31 should be skipped
+    rows = [(-1, 5, 5), (0, 10, 10), (31, 20, 20)]
+    res = _process_future_due_rows(rows, max_days=30)
+    assert len(res) == 31
+    assert res[0]['mature'] == 10
+    # Day 31 should not be in the results (length is 31: 0-30)
+    assert res[30]['mature'] == 0

--- a/stats_page_customizer/tests/test_stats_hooks.py
+++ b/stats_page_customizer/tests/test_stats_hooks.py
@@ -1,0 +1,208 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+_mock_aqt = MagicMock()
+
+
+class _FakeStatsClass:
+    def __init__(self, *a, **kw):
+        pass
+
+    def refresh(self, *a, **kw):
+        pass
+
+
+_mock_stats = MagicMock()
+_mock_stats.DeckStats = _FakeStatsClass
+_mock_stats.NewDeckStats = _FakeStatsClass
+
+sys.modules["aqt"] = _mock_aqt
+sys.modules["aqt.gui_hooks"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.stats"] = _mock_stats
+sys.modules["aqt.utils"] = MagicMock()
+sys.modules["aqt.webview"] = MagicMock()
+
+from stats_page_customizer import _on_stats_dialog_will_show, _patch_stats_class
+
+
+def test_on_stats_dialog_will_show_no_web():
+    stats_dialog = MagicMock()
+    del stats_dialog.web
+    _on_stats_dialog_will_show(stats_dialog)
+
+
+@patch('stats_page_customizer._attach_on_load')
+def test_on_stats_dialog_will_show_with_web(mock_attach):
+    stats_dialog = MagicMock()
+    stats_dialog.web = MagicMock()
+    _on_stats_dialog_will_show(stats_dialog)
+    mock_attach.assert_called_once_with(stats_dialog.web)
+
+
+def test_patch_stats_class_none():
+    _patch_stats_class(None)
+
+
+def test_patch_stats_class_no_refresh():
+    class TestClass:
+        def __init__(self):
+            pass
+
+    _patch_stats_class(TestClass)
+
+
+def test_patch_stats_class_patched():
+    class TestClass:
+        def __init__(self):
+            pass
+
+        def refresh(self):
+            pass
+
+    TestClass.__init__._stats_customizer_patched = True
+    _patch_stats_class(TestClass)
+
+
+def test_patch_stats_class_already_patched():
+    class TestClass:
+        def __init__(self):
+            pass
+
+        def refresh(self):
+            pass
+
+    # Mark it as already patched
+    TestClass.__init__._stats_customizer_patched = True
+
+    from stats_page_customizer import _patch_stats_class
+
+    _patch_stats_class(TestClass)
+
+    # It shouldn't change the init method since it's already patched
+    assert TestClass.__init__._stats_customizer_patched is True
+    # If it was repatched, it would have replaced the __init__ method entirely
+    # but we don't have a great way to verify that easily besides the fact
+    # that it didn't crash.
+
+
+@patch('stats_page_customizer._attach_on_load')
+def test_patch_stats_class_wrap_init(mock_attach):
+    class TestClass:
+        def __init__(self, web=None):
+            self.web = web
+
+        def refresh(self):
+            pass
+
+    from stats_page_customizer import _patch_stats_class
+
+    _patch_stats_class(TestClass)
+
+    # Create an instance to trigger the wrapped init
+    mock_web = MagicMock()
+    TestClass(web=mock_web)
+
+    mock_attach.assert_called_once_with(mock_web)
+
+
+@patch('stats_page_customizer._attach_on_load')
+def test_patch_stats_class_wrap_init_fallback_form(mock_attach):
+    class TestClass:
+        def __init__(self, form=None):
+            self.form = form
+
+        def refresh(self):
+            pass
+
+    from stats_page_customizer import _patch_stats_class
+
+    _patch_stats_class(TestClass)
+
+    mock_web = MagicMock()
+    mock_form = MagicMock()
+    mock_form.web = mock_web
+
+    # Trigger wrapped init
+    TestClass(form=mock_form)
+
+    mock_attach.assert_called_once_with(mock_web)
+
+
+@patch('stats_page_customizer._attach_on_load')
+def test_patch_stats_class_wrap_init_no_web(mock_attach):
+    class TestClass:
+        def __init__(self):
+            pass
+
+        def refresh(self):
+            pass
+
+    from stats_page_customizer import _patch_stats_class
+
+    _patch_stats_class(TestClass)
+
+    # Trigger wrapped init
+    TestClass()
+
+    mock_attach.assert_not_called()
+
+
+def test_patch_stats_class_wrap_refresh():
+    class TestClass:
+        def __init__(self):
+            pass
+
+        def refresh(self):
+            pass
+
+    from stats_page_customizer import _patch_stats_class, mw
+
+    _patch_stats_class(TestClass)
+
+    # Try calling refresh
+    instance = TestClass()
+
+    # Simply running it without error indicates success
+    instance.refresh()
+
+
+@patch('stats_page_customizer._schedule_js_eval')
+def test_patch_stats_class_wrap_refresh_with_web(mock_schedule):
+    class TestClass:
+        def __init__(self):
+            pass
+
+        def refresh(self):
+            pass
+
+    from stats_page_customizer import _patch_stats_class
+
+    _patch_stats_class(TestClass)
+
+    mock_web = MagicMock()
+    instance = TestClass()
+    instance.web = mock_web
+
+    instance.refresh()
+
+    mock_schedule.assert_called_once_with(mock_web)
+
+
+@patch('stats_page_customizer._attach_on_load')
+def test_patch_stats_class_wrap_init_log_attrs(mock_attach):
+    class TestClass:
+        def __init__(self, content="something"):
+            self.content = content
+
+        def refresh(self):
+            pass
+
+    from stats_page_customizer import _patch_stats_class
+
+    _patch_stats_class(TestClass)
+
+    # Trigger wrapped init
+    TestClass()
+
+    mock_attach.assert_not_called()

--- a/stats_page_customizer/tests/test_stats_process.py
+++ b/stats_page_customizer/tests/test_stats_process.py
@@ -1,0 +1,42 @@
+import sys
+from unittest.mock import MagicMock
+
+# Mock aqt with classes that support __init__ patching
+_mock_aqt = MagicMock()
+
+
+class _FakeStatsClass:
+    def __init__(self, *a, **kw):
+        pass
+
+    def refresh(self, *a, **kw):
+        pass
+
+
+_mock_stats = MagicMock()
+_mock_stats.DeckStats = _FakeStatsClass
+_mock_stats.NewDeckStats = _FakeStatsClass
+
+sys.modules["aqt"] = _mock_aqt
+sys.modules["aqt.gui_hooks"] = MagicMock()
+sys.modules["aqt.qt"] = MagicMock()
+sys.modules["aqt.stats"] = _mock_stats
+sys.modules["aqt.utils"] = MagicMock()
+sys.modules["aqt.webview"] = MagicMock()
+
+from stats_page_customizer import _process_future_due_rows
+
+
+def test_process_future_due_rows():
+    rows = [(0, 5, 2), (1, 10, 0), (5, 0, 3)]
+    res = _process_future_due_rows(rows, max_days=30)
+    assert len(res) == 31  # 0 to 30 inclusive
+    assert res[0]['day'] == 0
+    assert res[0]['mature'] == 5
+    assert res[0]['young'] == 2
+    assert res[1]['mature'] == 10
+    assert res[1]['young'] == 0
+    assert res[5]['mature'] == 0
+    assert res[5]['young'] == 3
+    assert res[2]['mature'] == 0
+    assert res[2]['young'] == 0


### PR DESCRIPTION
Identified and resolved gaps in test coverage for graph analysis tools and the stats customizer addon.
- Added tests for `graph/analyze.py::load_notes_with_decks` mapping fallback behavior and mock object resolution.
- Introduced tests for `stats_page_customizer/__init__.py::_gather_future_due` and related rows processing.
- Verified failure modes and state handling hooks in `_patch_stats_class`.
Coverage increased appropriately without altering application functionality.

---
*PR created automatically by Jules for task [13264134959474795713](https://jules.google.com/task/13264134959474795713) started by @ryusoh*