### PR TITLE
Bolt: Optimize findIndex with Map lookups in graph physics loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -262,3 +262,8 @@
 
 **Learning:** Calling `getBoundingClientRect()` on multiple parent elements inside a high-frequency animation loop (e.g., `gsap.ticker`) while modifying their children causes O(N) layout thrashing. Iterating through groups and alternating between reading parent bounds and writing child styles forces synchronous layout recalculations.
 **Action:** When updating multiple groups inside an animation loop, separate DOM reads and writes into two distinct phases. Pre-allocate an array, read all parent bounds in the first loop, and batch apply styles in the second loop to maintain 60fps performance.
+
+## 2026-06-11 - [Optimize findIndex in force simulation loop]
+
+**Learning:** Using `Array.findIndex()` repeatedly inside tight, high-frequency animation or physics simulation loops (like force-directed graphs) forces O(N) linear searches on every iteration, leading to significant CPU overhead and dropped frames.
+**Action:** Pre-calculate a `Map` linking identifiers (like `node.id`) to their array index during initialization. Inside the loop, replace O(N) `findIndex` calls with O(1) `Map.get()` lookups to drastically improve loop performance and maintain smooth framerates.

--- a/graph/create_3d_viz.py
+++ b/graph/create_3d_viz.py
@@ -197,14 +197,18 @@ graphData.nodes.forEach((n,i)=>{{
   scene.add(mesh);
 }});
 
+// Bolt: Pre-calculate node indices to replace O(N) findIndex lookups inside loops with O(1) hash map lookups.
+const nodeIdToIndex = new Map();
+graphData.nodes.forEach((n, i) => nodeIdToIndex.set(n.id, i));
+
 // Create edges with glow
 const edgeMaterial=new THREE.LineBasicMaterial({{color:0x00a8ff,transparent:true,opacity:0.3}});
 const edges_geometry=new THREE.BufferGeometry();
 const edgePositions=[];
 
 graphData.links.forEach(link=>{{
-  const sourceIndex=graphData.nodes.findIndex(n=>n.id===link.source);
-  const targetIndex=graphData.nodes.findIndex(n=>n.id===link.target);
+  const sourceIndex=nodeIdToIndex.has(link.source) ? nodeIdToIndex.get(link.source) : -1;
+  const targetIndex=nodeIdToIndex.has(link.target) ? nodeIdToIndex.get(link.target) : -1;
   if(sourceIndex>=0&&targetIndex>=0){{
     edgePositions.push(0,0,0,0,0,0); // Will be updated
   }}
@@ -246,8 +250,8 @@ for(let iter=0;iter<200;iter++){{
   
   // Attraction along edges
   graphData.links.forEach(link=>{{
-    const si=graphData.nodes.findIndex(n=>n.id===link.source);
-    const ti=graphData.nodes.findIndex(n=>n.id===link.target);
+    const si=nodeIdToIndex.has(link.source) ? nodeIdToIndex.get(link.source) : -1;
+    const ti=nodeIdToIndex.has(link.target) ? nodeIdToIndex.get(link.target) : -1;
     if(si>=0&&ti>=0){{
       const dx=positions[si].x-positions[ti].x;
       const dy=positions[si].y-positions[ti].y;
@@ -274,8 +278,8 @@ positions.forEach((pos,i)=>{{
 const edgePosAttr=edges_geometry.attributes.position;
 let edgeIdx=0;
 graphData.links.forEach(link=>{{
-  const si=graphData.nodes.findIndex(n=>n.id===link.source);
-  const ti=graphData.nodes.findIndex(n=>n.id===link.target);
+  const si=nodeIdToIndex.has(link.source) ? nodeIdToIndex.get(link.source) : -1;
+  const ti=nodeIdToIndex.has(link.target) ? nodeIdToIndex.get(link.target) : -1;
   if(si>=0&&ti>=0){{
     edgePosAttr.setXYZ(edgeIdx++,nodes_meshes[si].position.x,nodes_meshes[si].position.y,nodes_meshes[si].position.z);
     edgePosAttr.setXYZ(edgeIdx++,nodes_meshes[ti].position.x,nodes_meshes[ti].position.y,nodes_meshes[ti].position.z);

--- a/graph/quick_3d.py
+++ b/graph/quick_3d.py
@@ -140,6 +140,10 @@ for(let i=0;i<graphData.nodes.length;i++){{
   velocities.push({{x:0,y:0,z:0}});
 }}
 
+// Bolt: Pre-calculate node indices to replace O(N) findIndex lookups inside loops with O(1) hash map lookups.
+const nodeIdToIndex = new Map();
+graphData.nodes.forEach((n, i) => nodeIdToIndex.set(n.id, i));
+
 // Force-directed layout with bounds
 for(let iter=0;iter<150;iter++){{
   for(let i=0;i<positions.length;i++){{
@@ -159,8 +163,8 @@ for(let iter=0;iter<150;iter++){{
     }}
   }}
   graphData.links.forEach(link=>{{
-    const si=graphData.nodes.findIndex(n=>n.id===link.source);
-    const ti=graphData.nodes.findIndex(n=>n.id===link.target);
+    const si=nodeIdToIndex.has(link.source) ? nodeIdToIndex.get(link.source) : -1;
+    const ti=nodeIdToIndex.has(link.target) ? nodeIdToIndex.get(link.target) : -1;
     if(si>=0&&ti>=0){{
       const dx=positions[si].x-positions[ti].x,dy=positions[si].y-positions[ti].y,dz=positions[si].z-positions[ti].z;
       velocities[si].x-=dx*0.003;velocities[si].y-=dy*0.003;velocities[si].z-=dz*0.003;
@@ -187,8 +191,8 @@ const edgeMat=new THREE.LineBasicMaterial({{color:0x00a8ff,transparent:true,opac
 const edgeGeo=new THREE.BufferGeometry();
 const edgePos=[];
 graphData.links.forEach(link=>{{
-  const si=graphData.nodes.findIndex(n=>n.id===link.source);
-  const ti=graphData.nodes.findIndex(n=>n.id===link.target);
+  const si=nodeIdToIndex.has(link.source) ? nodeIdToIndex.get(link.source) : -1;
+  const ti=nodeIdToIndex.has(link.target) ? nodeIdToIndex.get(link.target) : -1;
   if(si>=0&&ti>=0){{
     edgePos.push(meshes[si].position.x,meshes[si].position.y,meshes[si].position.z);
     edgePos.push(meshes[ti].position.x,meshes[ti].position.y,meshes[ti].position.z);


### PR DESCRIPTION
💡 What: Replaced `findIndex` with O(1) `Map` lookups in `graph/create_3d_viz.py` and `graph/quick_3d.py`.
🎯 Why: Calling `findIndex` inside the heavy nested force-simulation physics loop causes massive O(N^2) CPU overhead and drops frames.
📊 Impact: Reduces simulation step time significantly and prevents GC pressure from internal iterations.
🔬 Measurement: Run the graph visualization and verify rendering maintains 60fps on large datasets.

---
*PR created automatically by Jules for task [17035655478968762087](https://jules.google.com/task/17035655478968762087) started by @ryusoh*