### PR TITLE
test: increase test coverage for util exception and edge cases

### DIFF
--- a/.jules/testpilot.md
+++ b/.jules/testpilot.md
@@ -173,3 +173,8 @@
 **Target:** `auto_image/__init__.py`, `auto_mathjax/__init__.py`, `auto_wiktionary/__init__.py`
 **Testing Strategy:** Added mock-based unit tests to cover previously untested exception handling (e.g. `flush` and `loadNoteKeepingFocus` failure blocks), early returns on `None` objects, and condition-specific edge cases (e.g., kanji redirects, whitespace-only content).
 **Learning:** Exception handling for Qt/Anki editor operations can be tricky to hit via standard unit tests, but `unittest.mock.patch` combined with `.side_effect = Exception(...)` on the mock objects effectively exercises these branches without altering the core logic.
+
+## 2024-05-20 - Exception Handling and Mock Injection
+
+**Learning:** Pytest's `unittest.mock.patch` combined with specific error constructors (like `urllib.error.HTTPError`) is essential to achieve full branch coverage in exception handling blocks, preventing silent unhandled failure paths.
+**Action:** When auditing coverage reports for utility modules (`utils.py`, `__init__.py`), actively mock side-effects and inject specific exceptions to simulate API timeouts or environment permission errors that normally evade "happy path" testing.

--- a/auto_wiktionary/tests/test_wiktionary_api.py
+++ b/auto_wiktionary/tests/test_wiktionary_api.py
@@ -249,3 +249,13 @@ def test_parse_wiktionary_html_kanji_char_multi_reading():
     assert "あま" in p_content
     # Definitions must still be present
     assert "空から降る水" in parsed
+
+
+def test_fetch_wiktionary_html_error():
+    from unittest.mock import patch
+    from urllib.error import HTTPError
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_urlopen.side_effect = HTTPError("url", 500, "Internal Server Error", {}, None)
+        res = fetch_wiktionary_html("error_word", "en")
+        assert res == "Error: 500"

--- a/stats_page_customizer/tests/test_stats_hooks.py
+++ b/stats_page_customizer/tests/test_stats_hooks.py
@@ -206,3 +206,80 @@ def test_patch_stats_class_wrap_init_log_attrs(mock_attach):
     TestClass()
 
     mock_attach.assert_not_called()
+
+
+def test_log_error(capsys):
+    from unittest.mock import patch
+
+    from stats_page_customizer import _log
+
+    with patch("stats_page_customizer.Path.mkdir", side_effect=Exception("mocked error")):
+        _log("test message")
+        captured = capsys.readouterr()
+        assert "Error writing to log file: mocked error" in captured.out
+
+
+def test_patch_stats_class_none():
+    from unittest.mock import patch
+
+    from stats_page_customizer import _patch_stats_class
+
+    with patch("stats_page_customizer._log") as mock_log:
+        _patch_stats_class(None)
+        mock_log.assert_called_with("Stats class missing; cannot patch.")
+
+
+def test_patch_stats_class_no_init():
+    from unittest.mock import patch
+
+    from stats_page_customizer import _patch_stats_class
+
+    class DummyClass:
+        pass
+
+    with patch("stats_page_customizer._log") as mock_log:
+        _patch_stats_class(DummyClass)
+        mock_log.assert_any_call(f"{DummyClass} lacks __init__ or refresh; cannot patch.")
+
+
+def test_patch_stats_class_dummy_with_web():
+    from unittest.mock import patch
+
+    from stats_page_customizer import _patch_stats_class
+
+    class DummyClassWithInit:
+        def __init__(self):
+            pass
+
+        def refresh(self):
+            pass
+
+    # Assign some dummy attributes to bypass initial checks and allow patching
+    # DummyClassWithInit._stats_customizer_patched is False by default
+
+    with (
+        patch("stats_page_customizer._log") as mock_log,
+        patch("stats_page_customizer._schedule_js_eval") as mock_schedule,
+    ):
+
+        _patch_stats_class(DummyClassWithInit)
+
+        # Test the wrapped __init__ sets up web properly
+        from unittest.mock import MagicMock
+
+        class FakeWeb:
+            def __init__(self):
+                self.loadFinished = MagicMock()
+                self._stats_customizer_connected = False
+
+        instance = DummyClassWithInit()
+        instance.web = FakeWeb()
+        # Since it calls original init, no problem, but to trigger the log in the wrapped init
+        # we have to re-invoke __init__ now that we've set `web` (or we can just mock the self.web to exist after original init).
+        # We can just call __init__ again to hit `if web:` block.
+        instance.__init__()
+        mock_log.assert_any_call("DummyClassWithInit.__init__ attaching webview via self.web.")
+
+        # Test the wrapped refresh schedules js
+        instance.refresh()
+        mock_schedule.assert_called_with(instance.web)

--- a/strip_html_tags/tests/test_strip_selection.py
+++ b/strip_html_tags/tests/test_strip_selection.py
@@ -204,3 +204,16 @@ def test_strip_field_edge_cases():
 
     mock_editor.currentField = 5
     _strip_field(mock_editor)
+
+
+def test_find_mismatches_none():
+    import sys
+    from io import StringIO
+    from unittest.mock import patch
+
+    from strip_html_tags import _find_mismatches
+
+    with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+        res = _find_mismatches("abc", "def")
+        assert res is None
+        assert "====== STRIP_HTML_DEBUG: Mismatch ======" in mock_stderr.getvalue()


### PR DESCRIPTION
This PR addresses three coverage gaps identified during TestPilot analysis:

1. **auto_wiktionary**: Added test for `fetch_wiktionary_html` to handle HTTP 500 exceptions thrown by `urllib.request.urlopen`.
2. **strip_html_tags**: Added test for `_find_mismatches` to properly mock `sys.stderr` when mismatches are entirely undetected (`idx == -1`).
3. **stats_page_customizer**: Added robust exception assertions for `_log` directory failures and verified edge cases where `_patch_stats_class` runs against classes missing `__init__` configurations or completely lacking components.

The focus is squarely on robust error condition and edge case checking. No production code was modified. Tests execute normally with `make check-py`.

---
*PR created automatically by Jules for task [11000763633286999866](https://jules.google.com/task/11000763633286999866) started by @ryusoh*